### PR TITLE
change Imagenet 1k sample image to new static url because of change in HF datasets-server API

### DIFF
--- a/first_5_steps/3_running_cv_models.ipynb
+++ b/first_5_steps/3_running_cv_models.ipynb
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# Load data sample from ImageNet-1k\n",
-    "url = \"https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg\"\n",
+    "url = \"https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg\"\n",
     "image = Image.open(requests.get(url, stream=True).raw)\n",
     "\n",
     "# View the image\n",

--- a/model_demos/cv_demos/mlpmixer/timm_mlpmixer.py
+++ b/model_demos/cv_demos/mlpmixer/timm_mlpmixer.py
@@ -28,7 +28,7 @@ def run_mlpmixer_timm():
     compiler_cfg.enable_t_streaming = True
 
     # Load data sample
-    url = "https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg"
+    url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
     image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
     label = "tiger"
 

--- a/model_demos/cv_demos/resnet/onnx_resnet.py
+++ b/model_demos/cv_demos/resnet/onnx_resnet.py
@@ -82,7 +82,7 @@ def run_resnet_onnx():
     os.environ["PYBUDA_FORCE_CONV_MULTI_OP_FRACTURE"] = "1"
 
     # Load data sample
-    url = "https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg"
+    url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
     image = Image.open(requests.get(url, stream=True).raw)
     label = "tiger"
 

--- a/model_demos/cv_demos/resnet/pytorch_resnet.py
+++ b/model_demos/cv_demos/resnet/pytorch_resnet.py
@@ -24,7 +24,7 @@ def run_resnet_pytorch(variant="microsoft/resnet-50"):
     os.environ["PYBUDA_PAD_OUTPUT_BUFFER"] = "1"
 
     # Load data sample
-    url = "https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg"
+    url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
     image = Image.open(requests.get(url, stream=True).raw)
     label = "tiger"
 

--- a/model_demos/cv_demos/resnet/timm_resnet.py
+++ b/model_demos/cv_demos/resnet/timm_resnet.py
@@ -25,7 +25,7 @@ def run_resnet_timm():
     compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
 
     # Load data sample
-    url = "https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg"
+    url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
     image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
     label = "tiger"
 


### PR DESCRIPTION
Demos using the previous static URLs from `https://datasets-server.huggingface.co/assets/imagenet-1k/` appear to no longer work because the HF https://datasets-server.huggingface.co API has changed for gated access datasets (e.g. Imagenet 1k). 

Example in resnet demo: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/resnet/pytorch_resnet.py#L28

### Reproduce

The current URL gives a 403 now, even after authenticating via huggingface-cli login: 
```
>>> import requests
>>> from PIL import Image
>>> url = "https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg"
>>> image = Image.open(requests.get(url, stream=True).raw)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "tt-buda-demos/model_demos/env/lib/python3.8/site-packages/PIL/Image.py", line 3309, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x1034c7ea0>
>>> requests.get(url, stream=True)
<Response [403]>


>>> # other images that are accessible via URL work
>>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
>>> image = Image.open(requests.get(url, stream=True).raw)
>>> image
<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=640x480 at 0x1035A3A00>
>>>
```

adding my HF token header to the requests directly also does not work:
```
wget --header="Authorization: Bearer $HF_TOKEN" https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg
...
HTTP request sent, awaiting response... 403 Forbidden

curl -X GET \
     -H "Authorization: Bearer $HF_TOKEN" \
     "https://datasets-server.huggingface.co/assets/imagenet-1k/--/default/train/18/image/image.jpg"
...
<?xml version="1.0" encoding="UTF-8"?><Error><Code>MissingKey</Code><Message>Missing Key-Pair-Id query parameter or cookie value</Message></Error>
```

### The new HF datasets-server API

To download images using the new datasets-server.huggingface.co API for gated datasets I needed to first get download URLs with a `Signature` and `Key-Pair-Id` query parameters using the rows API:
```
# Note: this doesn't work without HF_TOKEN
curl -X GET \
     -H "Authorization: Bearer $HF_TOKEN" \
     "https://datasets-server.huggingface.co/rows?dataset=imagenet-1k&config=default&split=train&offset=0&length=1"
```
Then download files via download URLs with `Signature` and `Key-Pair-Id` query parameters:
```
wget -O test1.jpg "https://datasets-server.huggingface.co/cached-assets/imagenet-1k/--/014711311cec8b5959350c373878a3311caeb764/--/default/train/93/image/image.jpg?Expires=1707261448&Signature=<signature>&Key-Pair-Id=<key-pair-id>"
```

### The fix for sample data

Using the new HF API for Imagenet 1k samples does not work very well because it requires the user to use their HF_TOKEN (and to create a HF account and find this token if they have not already) and would require some logic to parse the correct url from the first response.

For this reason I propose using a CC licensed public domain image from a fixed URL instead.
![new sample tiger image](https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg)

In future if this is a reoccurring concern we could host a simple sample data server, e.g. AWS S3 bucket with CloudFront.