### PR TITLE
Rename requirements-dev.txt and include requirements.txt in install

### DIFF
--- a/model_demos/CONTRIBUTING.md
+++ b/model_demos/CONTRIBUTING.md
@@ -21,11 +21,11 @@ All contributions require:
 
 ## Setting up environment
 
-Install all dependencies from [dev_requriements.txt](dev_requirements.txt) and install pre-commit hooks in a Python environment with PyBuda installed.
+Install all dependencies from [requriements-dev.txt](requirements-dev.txt) and install pre-commit hooks in a Python environment with PyBuda installed.
 
 ```bash
 cd model_demos
-pip install -r dev_requirements.txt
+pip install -r requirements-dev.txt
 pre-commit install
 ```
 

--- a/model_demos/requirements-dev.txt
+++ b/model_demos/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest==7.1.2
 black==22.3.0
 flake8==3.9.2


### PR DESCRIPTION
Rename the developer requirements txt file to `requirements-dev.txt` and add a recursive install command for `requirements.txt`.

This will simplify the environment setup for developers to one file only.