### PR TITLE
Anirud/tt buda installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,10 @@ archive/
 
 #  Ignore installable whl files and folders
 {pybuda-,tvm-}*.whl
+*.whl
+
+
+# System files / macOS
+.DS_Store
 
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -28,10 +28,11 @@ Once you have identified the release version you would like to install, you can 
    3. [Device Firmware Update](#device-firmware-update)
    4. [Backend Compiler Dependencies](#backend-compiler-dependencies)
    5. [TT-SMI](#tt-smi)
-   6. [Tenstorrent Software Package](#tenstorrent-software-package)
-   7. [Python Environment Installation](#python-environment-installation)
-   8. [Docker Container Installation](#docker-container-installation)
-   9. [Smoke Test](#smoke-test)
+2. [PyBuda Installation](#pybuda-installation)
+    1. [Python Environment Installation](#python-environment-installation)
+    2. [Docker Container Installation](#docker-container-installation)
+3. [Tests](#tests)
+   1. [Smoke Test](#smoke-test)
 
 ## Installation Instructions
 
@@ -76,14 +77,11 @@ apt-get install -y build-essential clang-6.0 libhdf5-serial-dev libzmq3-dev
 
 Please navigate to [tt-smi](https://github.com/tenstorrent/tt-smi).
 
-### Tenstorrent Software Package
 
-The directory contains instructions to install the PyBuda and TVM software stack. This package consists of the following files:
+## PyBuda Installation
 
-```bash
-pybuda-<version>.whl   <- Latest PyBuda Release
-tvm-<version>.whl      <- Latest TVM Release
-```
+There are two ways to install PyBuda within the host environment: using Python virtual environment or Docker container.
+
 
 ### Python Environment Installation
 
@@ -145,6 +143,10 @@ sudo docker run --rm -ti --cap-add=sys_nice --shm-size=4g --device /dev/tenstorr
 ```bash
 cd home/
 ```
+
+## Tests
+
+Use the smoke test to check for correct installation of PyBuda library and environment.
 
 ### Smoke Test
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -150,7 +150,7 @@ cd home/
 
 ## Tests
 
-Use the smoke test to check for correct installation of PyBuda library and environment.
+Verify the correct installation of the PyBuda library and environment by conducting a smoke test.
 
 ### Smoke Test
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -54,20 +54,22 @@ sudo reboot
 
 ### PCI Driver Installation
 
-Please navigate to [tt-kmd](https://github.com/tenstorrent/tt-kmd).
+Please navigate to [tt-kmd](https://github.com/tenstorrent/tt-kmd) homepage and follow instructions within the README. 
+*Pro-Tip: ensure that you are within the home directory of the local clone version of [tt-kmd](https://github.com/tenstorrent/tt-kmd) when performing the installation steps*
 
 ### Device Firmware Update
 
-The [tt-firmware-gs](https://github.com/tenstorrent/tt-firmware-gs) firmware file needs to be installed using the [tt-flash](https://github.com/tenstorrent/tt-flash) utility, for more details visit [TT-Flash homepage](https://github.com/tenstorrent/tt-flash?tab=readme-ov-file#firmware-files:~:text=Firmware%20files,of%20the%20images.)
+The [tt-firmware-gs](https://github.com/tenstorrent/tt-firmware-gs) firmware file needs to be installed using the [tt-flash](https://github.com/tenstorrent/tt-flash) utility, for more details visit [TT-Flash homepage](https://github.com/tenstorrent/tt-flash?tab=readme-ov-file#firmware-files:~:text=Firmware%20files,of%20the%20images.) and follow instructions within the README.
 
 ### Backend Compiler Dependencies
 
 Instructions to install the Tenstorrent backend compiler dependencies on a fresh install of Ubuntu Server 20.04.
 
-You may need to append each `apt-get` command with `sudo` if you do not have root permissions.
+*You may need to **append** each `apt-get` command with `sudo` if you do not have root permissions.*
 
 ```bash
-apt-get update -y && apt-get upgrade -y --no-install-recommends
+apt-get update -y
+apt-get upgrade -y --no-install-recommends
 apt-get install -y software-properties-common
 apt-get install -y python3.8-venv libboost-all-dev libgoogle-glog-dev libgl1-mesa-glx libyaml-cpp-dev ruby
 apt-get install -y build-essential clang-6.0 libhdf5-serial-dev libzmq3-dev
@@ -75,8 +77,7 @@ apt-get install -y build-essential clang-6.0 libhdf5-serial-dev libzmq3-dev
 
 ### TT-SMI
 
-Please navigate to [tt-smi](https://github.com/tenstorrent/tt-smi).
-
+Please navigate to [tt-smi](https://github.com/tenstorrent/tt-smi) homepage and follow instructions within the README.
 
 ## PyBuda Installation
 
@@ -109,6 +110,9 @@ source env/bin/activate
 ```bash
 pip install pybuda-<version>.whl tvm-<version>.whl
 ```
+The `pybuda-<version>.whl` file contains the PyBuda and `tvm-<version>.whl` file contains the latest TVM downloaded release(s).
+
+---
 
 ### Docker Container Installation
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -59,7 +59,7 @@ Please navigate to [tt-kmd](https://github.com/tenstorrent/tt-kmd) homepage and 
 
 ### Device Firmware Update
 
-The [tt-firmware-gs](https://github.com/tenstorrent/tt-firmware-gs) firmware file needs to be installed using the [tt-flash](https://github.com/tenstorrent/tt-flash) utility, for more details visit [TT-Flash homepage](https://github.com/tenstorrent/tt-flash?tab=readme-ov-file#firmware-files:~:text=Firmware%20files,of%20the%20images.) and follow instructions within the README.
+The [tt-firmware](https://github.com/tenstorrent/tt-firmware) file needs to be installed using the [tt-flash](https://github.com/tenstorrent/tt-flash) utility, for more details visit [TT-Flash homepage](https://github.com/tenstorrent/tt-flash?tab=readme-ov-file#firmware-files:~:text=Firmware%20files,of%20the%20images.) and follow instructions within the README.
 
 ### Backend Compiler Dependencies
 


### PR DESCRIPTION
Changes in this PR

Edits to 1_install_tt_buda.md

- some edits to better explain install of [tt-kmd](https://github.com/tenstorrent/tt-buda-demos/blob/073130bc8cf7dc13a9e68edf626246a851073ce4/first_5_steps/1_install_tt_buda.md#:~:text=Please%20navigate%20to%20tt%2Dkmd%20homepage%20and%20follow%20instructions%20within%20the%20README.%20Pro%2DTip%3A%20ensure%20that%20you%20are%20within%20the%20home%20directory%20of%20the%20local%20clone%20version%20of%20tt%2Dkmd%20when%20performing%20the%20installation%20steps) because I noticed other people having the same error on a slack channel-- Ported from closed PR
- The install instructions have been updated to explicitly direct users to the README file of the specific utility they intend to install-- ported from closed PR
- Table of contents have been modified
  - remove Tenstorrent Software Package subheading
  - move python and docker PyBuda install instructions to its own subheading 
- installation instructions are in their own section
- smoke test and the new sanity script are under a section called Test


Edits to the .gitignore file

- to ensure it now ignore all files with the extension whl
- ignore mac os generated files like .DS store