### PR TITLE
Add support for python3.10

### DIFF
--- a/model_demos/cv_demos/yolo_v3/holli_src/yolov3_base.py
+++ b/model_demos/cv_demos/yolo_v3/holli_src/yolov3_base.py
@@ -1,6 +1,7 @@
 import importlib
 from abc import ABCMeta, abstractmethod
-from collections import Iterable, OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
### Changes
*  Import `Iterable` from [collections.abc](https://docs.python.org/3.10/library/collections.abc.html#module-collections.abc) to support python3.10