### PR TITLE
Update backend compiler dependencies for Ubuntu Server 22.04.

### DIFF
--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -91,7 +91,7 @@ dpkg -i libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb libyaml-cpp0.6_0.6.2-4ubuntu1_a
 rm libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
 ```
 
-Then in both operating system run the following command:
+Then, for both operating systems, run:
 
 ```bash
 apt install -y python3-pip python-is-python3 && rm -rf /var/lib/apt/lists/*

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -82,7 +82,7 @@ apt install -y clang-6.0 libyaml-cpp-dev libzmq3-dev python3.8-venv
 pip3 install -U pip
 ```
 
-For Ubuntu 22.04, you would add:
+For Ubuntu 22.04, add:
 ```bash
 apt install -y python3-venv clang wget
 wget http://mirrors.kernel.org/ubuntu/pool/main/y/yaml-cpp/libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -65,7 +65,7 @@ The [tt-firmware](https://github.com/tenstorrent/tt-firmware) file needs to be i
 
 Instructions to install the Tenstorrent backend compiler dependencies on a fresh install of Ubuntu Server 20.04 or Ubuntu Server 22.04.
 
-*You may need to **append** each `apt-get` command with `sudo` if you do not have root permissions.*
+*You may need to **append** each `apt` command with `sudo` if you do not have root permissions.*
 
 For both operating systems run the following commands:
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -70,7 +70,7 @@ Instructions to install the Tenstorrent backend compiler dependencies on a fresh
 For both operating systems run the following commands:
 
 ```bash
-apt-get update -y
+apt update -y
 apt-get upgrade -y --no-install-recommends
 apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-glog-dev libhdf5-serial-dev ruby software-properties-common libzmq3-dev 
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -76,7 +76,7 @@ apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-g
 
 ```
 
-Then, for Ubuntu 20.04, you would add:
+For Ubuntu 20.04, add:
 ```bash
 apt install -y clang-6.0 libyaml-cpp-dev libzmq3-dev python3.8-venv 
 pip3 install -U pip

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -72,29 +72,22 @@ For both operating systems run the following commands:
 ```bash
 apt update -y
 apt upgrade -y --no-install-recommends
-apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-glog-dev libhdf5-serial-dev ruby software-properties-common libzmq3-dev 
+apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-glog-dev libhdf5-serial-dev ruby software-properties-common libzmq3-dev clang wget python3-pip python-is-python3 python3-venv
 
 ```
 
 For Ubuntu 20.04, add:
 ```bash
-apt install -y clang-6.0 libyaml-cpp-dev python3.8-venv 
-```
+apt install -y libyaml-cpp-dev
 
 For Ubuntu 22.04, add:
 ```bash
-apt install -y python3-venv clang wget
 wget http://mirrors.kernel.org/ubuntu/pool/main/y/yaml-cpp/libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb
 wget http://mirrors.kernel.org/ubuntu/pool/main/y/yaml-cpp/libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
 dpkg -i libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
 rm libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
 ```
 
-Then, for both operating systems, run:
-
-```bash
-apt install -y python3-pip python-is-python3 && rm -rf /var/lib/apt/lists/*
-```
 
 ### TT-SMI
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -12,7 +12,7 @@ While TT-Buda is the official Tenstorrent AI/ML compiler stack, PyBuda is the Py
 
 ### OS Compatibility
 
-Presently, Tenstorrent software is only supported on the **Ubuntu 20.04 LTS (Focal Fossa)** operating system.
+Currently our Tenstorrent software can be access on **Ubuntu 20.04 LTS (Focal Fossa)** and **Ubuntu 20.04 LTS (Jammy Jellyfish)** operating systems. 
 
 ## Release Versions
 
@@ -63,16 +63,38 @@ The [tt-firmware](https://github.com/tenstorrent/tt-firmware) file needs to be i
 
 ### Backend Compiler Dependencies
 
-Instructions to install the Tenstorrent backend compiler dependencies on a fresh install of Ubuntu Server 20.04.
+Instructions to install the Tenstorrent backend compiler dependencies on a fresh install of Ubuntu Server 20.04 or Ubuntu Server 22.04.
 
 *You may need to **append** each `apt-get` command with `sudo` if you do not have root permissions.*
+
+For both operating systems run the following commands:
 
 ```bash
 apt-get update -y
 apt-get upgrade -y --no-install-recommends
-apt-get install -y software-properties-common
-apt-get install -y python3.8-venv libboost-all-dev libgoogle-glog-dev libgl1-mesa-glx libyaml-cpp-dev ruby
-apt-get install -y build-essential clang-6.0 libhdf5-serial-dev libzmq3-dev
+apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-glog-dev libhdf5-serial-dev ruby software-properties-common libzmq3-dev 
+
+```
+
+Then, for Ubuntu 20.04, you would add:
+```bash
+apt install -y clang-6.0 libyaml-cpp-dev libzmq3-dev python3.8-venv 
+pip3 install -U pip
+```
+
+For Ubuntu 22.04, you would add:
+```bash
+apt install -y python3-venv clang wget
+wget http://mirrors.kernel.org/ubuntu/pool/main/y/yaml-cpp/libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb
+wget http://mirrors.kernel.org/ubuntu/pool/main/y/yaml-cpp/libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
+dpkg -i libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
+rm libyaml-cpp-dev_0.6.2-4ubuntu1_amd64.deb libyaml-cpp0.6_0.6.2-4ubuntu1_amd64.deb
+```
+
+Then in both operating system run the following command:
+
+```bash
+apt install -y python3-pip python-is-python3 && rm -rf /var/lib/apt/lists/*
 ```
 
 ### TT-SMI

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -79,6 +79,7 @@ apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-g
 For Ubuntu 20.04, add:
 ```bash
 apt install -y libyaml-cpp-dev
+```
 
 For Ubuntu 22.04, add:
 ```bash

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -71,7 +71,7 @@ For both operating systems run the following commands:
 
 ```bash
 apt update -y
-apt-get upgrade -y --no-install-recommends
+apt upgrade -y --no-install-recommends
 apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-glog-dev libhdf5-serial-dev ruby software-properties-common libzmq3-dev 
 
 ```

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -79,7 +79,6 @@ apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-g
 For Ubuntu 20.04, add:
 ```bash
 apt install -y clang-6.0 libyaml-cpp-dev libzmq3-dev python3.8-venv 
-pip3 install -U pip
 ```
 
 For Ubuntu 22.04, add:

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -12,7 +12,7 @@ While TT-Buda is the official Tenstorrent AI/ML compiler stack, PyBuda is the Py
 
 ### OS Compatibility
 
-Currently our Tenstorrent software can be access on **Ubuntu 20.04 LTS (Focal Fossa)** and **Ubuntu 20.04 LTS (Jammy Jellyfish)** operating systems. 
+Currently, Tenstorrent software is supported on **Ubuntu 20.04 LTS (Focal Fossa)** and **Ubuntu 20.04 LTS (Jammy Jellyfish)** operating systems. 
 
 ## Release Versions
 

--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -78,7 +78,7 @@ apt install -y build-essential curl libboost-all-dev libgl1-mesa-glx libgoogle-g
 
 For Ubuntu 20.04, add:
 ```bash
-apt install -y clang-6.0 libyaml-cpp-dev libzmq3-dev python3.8-venv 
+apt install -y clang-6.0 libyaml-cpp-dev python3.8-venv 
 ```
 
 For Ubuntu 22.04, add:

--- a/model_demos/requirements.txt
+++ b/model_demos/requirements.txt
@@ -7,6 +7,5 @@ torchxrayvision==0.0.39  # For DenseNet
 yolov5==7.0.9  # For YOLOv5
 soundfile==0.12.1  # For Whisper
 librosa==0.10.0  # For Whisper
-numba==0.53.1  # For Whisper
 segmentation-models-pytorch==0.3.3  # For U-Net
 diffusers==0.14.0  # For Stable Diffusion


### PR DESCRIPTION
This pull request updates the backend compiler dependencies specifically for Ubuntu Server 22.04. In addition, it revises the section to provide clearer guidance for users to install dependencies for both Ubuntu Server 22.04 and Ubuntu Server 20.04.

 Test on the following / Add the following changes 

- [x] Test the back-end dependencies on GS, WH- on fresh ubuntu 20.04 docker image.
- [x] Test the back-end dependencies on GS, WH - on a fresh ubuntu 22.04 docker image.
- [x] Remove the numba==0.53.1 dependency from requirements.txt since it causes errors.
- [x] Update all back-end dependencies command to use just a apt and not the apt-get to maintain uniformity 
- [x] remove pip3 install -U pip from the changes since its duplicated https://github.com/tenstorrent/tt-buda-demos/pull/38#discussion_r1548628698
- [x] wget to common commands between OS
- [x] clang to common commands between OS
- [x]  python3-pip python-is-python3 to common commands between OS
- [x]  python3-venv to common command between OS