### PR TITLE
Add Perceiver IO demo

### DIFF
--- a/model_demos/README.md
+++ b/model_demos/README.md
@@ -59,6 +59,7 @@ python cv_demos/resnet/pytorch_resnet.py
 |   [OpenPose](cv_demos/openpose/)          |     GS, WH   |
 |   [OPT](nlp_demos/opt/)                  |     GS, WH   |
 |   [Pose Landmark](cv_demos/landmark/)  |    WH   |
+|   [Perceiver IO](cv_demos/perceiverio/) |     GS, WH   |
 |   [ResNet](cv_demos/resnet/)            |     GS, WH   |
 |   [ResNeXt](cv_demos/resnext/)          |     GS, WH   |
 |   [RetinaNet](cv_demos/retinanet/)      |     GS, WH   |

--- a/model_demos/README.md
+++ b/model_demos/README.md
@@ -78,3 +78,8 @@ python cv_demos/resnet/pytorch_resnet.py
 |   [XGLM](nlp_demos/xglm/)                                    |     GS, WH   | v0.10.5 |
 |   [YOLOv3](cv_demos/yolo_v3/)                                |     GS, WH   | v0.10.5 |
 |   [YOLOv5](cv_demos/yolo_v5/)                                |     GS, WH   | v0.10.5 |
+
+
+## Note:
+
+Please note that alpha relases are not stable releases and may not support or have all functionality as the stable releaes. If full functionality is needed we suggest picking a stable relases.

--- a/model_demos/README.md
+++ b/model_demos/README.md
@@ -27,54 +27,54 @@ python cv_demos/resnet/pytorch_resnet.py
 
 ## Models Support Table
 
-| **Model** | **Supported Hardware** <br /> GS - Grayskull <br /> WH - Wormhole |
-|-------------------------------------------|:--------:|
-|   [ALBERT](nlp_demos/albert/)            |     GS, WH   |
-|   [Autoencoder (convolutional)](cv_demos/conv_autoencoder/)  |     GS, WH   |
-|   [Autoencoder (linear)](cv_demos/linear_autoencoder/)  |     GS, WH   |
-|   [BeiT](cv_demos/beit/)                |     GS, WH   |
-|   [BERT](nlp_demos/bert/)                |     GS, WH   |
-|   [CLIP](cv_demos/clip/)                |     GS, WH   |
-|   [CodeGen](nlp_demos/codegen/)          |     GS, WH   |
-|   [DeiT](cv_demos/deit/)                |     GS, WH   |
-|   [DenseNet](cv_demos/densenet/)        |     GS, WH   |
-|   [DistilBERT](nlp_demos/distilbert/)    |     GS, WH   |
-|   [DPR](nlp_demos/dpr/)                  |     GS, WH   |
-|   [EfficientNet-Lite](cv_demos/efficientnet_lite/) |     WH   |
-|   [Falcon-7B](nlp_demos/falcon/)               |    WH   |
-|   [FLAN-T5](nlp_demos/flant5/)           |     GS, WH   |
-|   [Fuyu-8B](nlp_demos/fuyu8b/)          |       |
-|   [GhostNet](cv_demos/ghostnet/)         |     GS, WH   |
-|   [GoogLeNet](cv_demos/googlenet/)      |     GS, WH   |
-|   [GPT-2](nlp_demos/gpt2/)               |     GS, WH   |
-|   [GPT Neo](nlp_demos/gptneo/)           |     GS, WH   |
-|   [Hand Landmark](cv_demos/landmark/)  |    WH   |
-|   [HRNet](cv_demos/hrnet/)              |     GS, WH   |
-|   [Inception-v4](cv_demos/inceptionv4/) |    GS, WH   |
-|   [MLP-Mixer](cv_demos/mlpmixer/)  |     GS, WH   |
-|   [MobileNetSSD](cv_demos/mobilenet_ssd/)  |     WH   |
-|   [MobileNetV1](cv_demos/mobilenet_v1/)  |     GS, WH   |
-|   [MobileNetV2](cv_demos/mobilenet_v2/)  |     GS, WH   |
-|   [MobileNetV3](cv_demos/mobilenet_v3/)  |     GS, WH   |
-|   [OpenPose](cv_demos/openpose/)          |     GS, WH   |
-|   [OPT](nlp_demos/opt/)                  |     GS, WH   |
-|   [Pose Landmark](cv_demos/landmark/)  |    WH   |
-|   [Perceiver IO](cv_demos/perceiverio/) |     GS, WH   |
-|   [ResNet](cv_demos/resnet/)            |     GS, WH   |
-|   [ResNeXt](cv_demos/resnext/)          |     GS, WH   |
-|   [RetinaNet](cv_demos/retinanet/)      |     GS, WH   |
-|   [RoBERTa](nlp_demos/roberta/)          |     GS, WH   |
-|   [SqueezeBERT](nlp_demos/squeezebert/)  |     GS, WH   |
-|   [Stable Diffusion](cv_demos/stable_diffusion/)    |    WH   |
-|   [T5](nlp_demos/t5/)                    |     GS, WH   |
-|   [U-Net](cv_demos/unet/)               |    GS, WH   |
-|   [VGG](cv_demos/vgg/)                  |     GS, WH   |
-|   [ViT](cv_demos/vit/)                  |     GS, WH   |
-|   [ViLT](cv_demos/vilt/)                  |     GS, WH   |
-|   [VoVNet](cv_demos/vovnet/)            |     GS, WH   |
-|   [WideResNet](cv_demos/wideresnet/)      |     GS, WH   |
-|   [Whisper](audio_demos/whisper/)          |     GS, WH   |
-|   [Xception](cv_demos/xception/)        |     GS, WH   |
-|   [XGLM](nlp_demos/xglm/)                |     GS, WH   |
-|   [YOLOv3](cv_demos/yolo_v3/)            |     GS, WH   |
-|   [YOLOv5](cv_demos/yolo_v5/)            |     GS, WH   |
+| **Model** | **Supported Hardware** <br> GS - Grayskull <br> WH - Wormhole | **Supported Release** |
+|--------------------------------------------------------------|:------------:|:-------:|
+|   [ALBERT](nlp_demos/albert/)                                |     GS, WH   | v0.10.5 |
+|   [Autoencoder (convolutional)](cv_demos/conv_autoencoder/)  |     GS, WH   | v0.10.5 |
+|   [Autoencoder (linear)](cv_demos/linear_autoencoder/)       |     GS, WH   | v0.10.5 |
+|   [BeiT](cv_demos/beit/)                                     |     GS, WH   | v0.10.5 |
+|   [BERT](nlp_demos/bert/)                                    |     GS, WH   | v0.10.5 |
+|   [CLIP](cv_demos/clip/)                                     |     GS, WH   | v0.10.5 |
+|   [CodeGen](nlp_demos/codegen/)                              |     GS, WH   | v0.10.5 |
+|   [DeiT](cv_demos/deit/)                                     |     GS, WH   | v0.10.5 |
+|   [DenseNet](cv_demos/densenet/)                             |     GS, WH   | v0.10.5 |
+|   [DistilBERT](nlp_demos/distilbert/)                        |     GS, WH   | v0.10.5 |
+|   [DPR](nlp_demos/dpr/)                                      |     GS, WH   | v0.10.5 |
+|   [EfficientNet-Lite](cv_demos/efficientnet_lite/)           |         WH   | v0.10.5 |
+|   [Falcon-7B](nlp_demos/falcon/)                             |         WH   | v0.10.5 |
+|   [FLAN-T5](nlp_demos/flant5/)                               |     GS, WH   | v0.10.5 |
+|   [Fuyu-8B](nlp_demos/fuyu8b/)                               |              |         |
+|   [GhostNet](cv_demos/ghostnet/)                             |     GS, WH   | v0.10.5 |
+|   [GoogLeNet](cv_demos/googlenet/)                           |     GS, WH   | v0.10.5 |
+|   [GPT-2](nlp_demos/gpt2/)                                   |     GS, WH   | v0.10.5 |
+|   [GPT Neo](nlp_demos/gptneo/)                               |     GS, WH   | v0.10.5 |
+|   [Hand Landmark](cv_demos/landmark/)                        |         WH   | v0.10.5 |
+|   [HRNet](cv_demos/hrnet/)                                   |     GS, WH   | v0.10.5 |
+|   [Inception-v4](cv_demos/inceptionv4/)                      |     GS, WH   | v0.10.5 |
+|   [MLP-Mixer](cv_demos/mlpmixer/)                            |     GS, WH   | v0.10.5 |
+|   [MobileNetSSD](cv_demos/mobilenet_ssd/)                    |         WH   | v0.10.5 |
+|   [MobileNetV1](cv_demos/mobilenet_v1/)                      |     GS, WH   | v0.10.5 |
+|   [MobileNetV2](cv_demos/mobilenet_v2/)                      |     GS, WH   | v0.10.5 |
+|   [MobileNetV3](cv_demos/mobilenet_v3/)                      |     GS, WH   | v0.10.5 |
+|   [OpenPose](cv_demos/openpose/)                             |     GS, WH   | v0.10.5 |
+|   [OPT](nlp_demos/opt/)                                      |     GS, WH   | v0.10.5 |
+|   [Pose Landmark](cv_demos/landmark/)                        |         WH   | v0.10.5 |
+|   [Perceiver IO](cv_demos/perceiverio/)                      |     GS, WH   | v0.10.9-alpha |
+|   [ResNet](cv_demos/resnet/)                                 |     GS, WH   | v0.10.5 |
+|   [ResNeXt](cv_demos/resnext/)                               |     GS, WH   | v0.10.5 |
+|   [RetinaNet](cv_demos/retinanet/)                           |     GS, WH   | v0.10.5 |
+|   [RoBERTa](nlp_demos/roberta/)                              |     GS, WH   | v0.10.5 |
+|   [SqueezeBERT](nlp_demos/squeezebert/)                      |     GS, WH   | v0.10.5 |
+|   [Stable Diffusion](cv_demos/stable_diffusion/)             |         WH   | v0.10.5 |
+|   [T5](nlp_demos/t5/)                                        |     GS, WH   | v0.10.5 |
+|   [U-Net](cv_demos/unet/)                                    |     GS, WH   | v0.10.5 |
+|   [VGG](cv_demos/vgg/)                                       |     GS, WH   | v0.10.5 |
+|   [ViT](cv_demos/vit/)                                       |     GS, WH   | v0.10.5 |
+|   [ViLT](cv_demos/vilt/)                                     |     GS, WH   | v0.10.5 |
+|   [VoVNet](cv_demos/vovnet/)                                 |     GS, WH   | v0.10.5 |
+|   [WideResNet](cv_demos/wideresnet/)                         |     GS, WH   | v0.10.5 |
+|   [Whisper](audio_demos/whisper/)                            |     GS, WH   | v0.10.5 |
+|   [Xception](cv_demos/xception/)                             |     GS, WH   | v0.10.5 |
+|   [XGLM](nlp_demos/xglm/)                                    |     GS, WH   | v0.10.5 |
+|   [YOLOv3](cv_demos/yolo_v3/)                                |     GS, WH   | v0.10.5 |
+|   [YOLOv5](cv_demos/yolo_v5/)                                |     GS, WH   | v0.10.5 |

--- a/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
+++ b/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
@@ -1,0 +1,46 @@
+# Perceiver IO Demo Script
+
+import os
+
+import pybuda
+import requests
+from PIL import Image
+from transformers import AutoImageProcessor, PerceiverForImageClassificationConvProcessing
+
+
+def run_perceiverio_pytorch(variant="deepmind/vision-perceiver-conv"):
+
+    # Load ResNet feature extractor and model checkpoint from HuggingFace
+    model_ckpt = variant
+    image_processor = AutoImageProcessor.from_pretrained(model_ckpt)
+    model = PerceiverForImageClassificationConvProcessing.from_pretrained(model_ckpt).eval()
+
+    # Set PyBuda configuration parameters
+    compiler_cfg = pybuda.config._get_global_compiler_config()
+    compiler_cfg.balancer_policy = "Ribbon"
+    compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
+    os.environ["PYBUDA_RIBBON2"] = "1"
+    os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = f"{10*1024}"
+
+    # Load data sample
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    label = "tabby, tabby cat"
+
+    # Data preprocessing
+    inputs = image_processor(image, return_tensors="pt")
+    pixel_values = inputs["pixel_values"]
+
+    # Run inference on Tenstorrent device
+    output_q = pybuda.run_inference(pybuda.PyTorchModule("pt_resnet50", model), inputs=[(pixel_values,)])
+    output = output_q.get()  # return last queue object
+
+    # Data postprocessing
+    predicted_value = output[0].value().argmax(-1).item()
+    predicted_label = model.config.id2label[predicted_value]
+
+    print(f"True Label: {label} | Predicted Label: {predicted_label}")
+
+
+if __name__ == "__main__":
+    run_perceiverio_pytorch()

--- a/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
+++ b/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
@@ -20,6 +20,7 @@ def run_perceiverio_pytorch(variant="deepmind/vision-perceiver-conv"):
     compiler_cfg.balancer_policy = "Ribbon"
     compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
     compiler_cfg.default_dram_parameters = False
+    compiler_cfg.enable_auto_fusing = False
     os.environ["PYBUDA_RIBBON2"] = "1"
     os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = f"{10*1024}"
 

--- a/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
+++ b/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
@@ -19,6 +19,7 @@ def run_perceiverio_pytorch(variant="deepmind/vision-perceiver-conv"):
     compiler_cfg = pybuda.config._get_global_compiler_config()
     compiler_cfg.balancer_policy = "Ribbon"
     compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
+    compiler_cfg.default_dram_parameters = False
     os.environ["PYBUDA_RIBBON2"] = "1"
     os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = f"{10*1024}"
 

--- a/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
+++ b/model_demos/cv_demos/perceiverio/pytorch_perceiverio.py
@@ -32,7 +32,7 @@ def run_perceiverio_pytorch(variant="deepmind/vision-perceiver-conv"):
     pixel_values = inputs["pixel_values"]
 
     # Run inference on Tenstorrent device
-    output_q = pybuda.run_inference(pybuda.PyTorchModule("pt_resnet50", model), inputs=[(pixel_values,)])
+    output_q = pybuda.run_inference(pybuda.PyTorchModule("pt_perceiver_io", model), inputs=[(pixel_values,)])
     output = output_q.get()  # return last queue object
 
     # Data postprocessing

--- a/model_demos/pyproject.toml
+++ b/model_demos/pyproject.toml
@@ -80,4 +80,5 @@ markers = [
     "wideresnet: tests that involve WideResNet",
     "xception: tests that involve Xception",
     "ghostnet: tests that involve GhostNet",
+    "perceiverio: tests that involve Perceiver IO",
 ]

--- a/model_demos/tests/test_pytorch_perceiverio.py
+++ b/model_demos/tests/test_pytorch_perceiverio.py
@@ -1,0 +1,8 @@
+import pytest
+
+from cv_demos.perceiverio.pytorch_perceiverio import run_perceiverio_pytorch
+
+
+@pytest.mark.perceiverio
+def test_perceiverio_pytorch(clear_pybuda):
+    run_perceiverio_pytorch()


### PR DESCRIPTION
Test by running the following command from `model_demos` on latest alpha release (v0.10.9-alpha):

```bash
python3 -m pytest tests/test_pytorch_perceiverio.py
```