### PR TITLE
Patch update to support YOLOv3 on Python 3.10

### DIFF
--- a/model_demos/cv_demos/yolo_v3/holli_src/yolov3_base.py
+++ b/model_demos/cv_demos/yolo_v3/holli_src/yolov3_base.py
@@ -1,6 +1,7 @@
 import importlib
 from abc import ABCMeta, abstractmethod
-from collections import Iterable, OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Fixes import path for `from collections.abc import Iterable` to support Python 3.10