### PR TITLE
Update version of black=24.4.0 to patch ReDoS vulnerability

### DIFF
--- a/model_demos/cv_demos/hardnet/pytorch_hardnet.py
+++ b/model_demos/cv_demos/hardnet/pytorch_hardnet.py
@@ -62,7 +62,7 @@ def run_hardnet_pytorch(variant):
     )
     try:
         urllib.URLopener().retrieve(url, filename)
-    except:
+    except Exception:
         urllib.request.urlretrieve(url, filename)
 
     input_image = Image.open(filename)

--- a/model_demos/cv_demos/stable_diffusion/pytorch_stable_diffusion.py
+++ b/model_demos/cv_demos/stable_diffusion/pytorch_stable_diffusion.py
@@ -255,7 +255,13 @@ def run_stable_diffusion_pytorch(variant="CompVis/stable-diffusion-v1-4"):
     print("Generating image for prompt: ", prompt)
 
     # Data preprocessing
-    (latents, timesteps, extra_step_kwargs, prompt_embeds, extra_step_kwargs,) = stable_diffusion_preprocessing(
+    (
+        latents,
+        timesteps,
+        extra_step_kwargs,
+        prompt_embeds,
+        extra_step_kwargs,
+    ) = stable_diffusion_preprocessing(
         pipe,
         prompt,
         num_inference_steps=num_inference_steps,

--- a/model_demos/cv_demos/vgg/pytorch_vgg_timm.py
+++ b/model_demos/cv_demos/vgg/pytorch_vgg_timm.py
@@ -29,7 +29,6 @@ def preprocess_timm_model(model_name):
 
 
 def run_vgg_bn19_timm_pytorch(variant="vgg19_bn"):
-
     """
     Variants = {
      'vgg11':

--- a/model_demos/cv_demos/yolo_v3/holli_src/utils.py
+++ b/model_demos/cv_demos/yolo_v3/holli_src/utils.py
@@ -115,6 +115,7 @@ def multi_bbox_ious(boxes1, boxes2, x1y1x2y2=True):
 
 # Plotting helpers
 
+
 # e.g. plot_multi_detections(img_tensor, model.predict_img(img_tensor))
 def plot_multi_detections(imgs, results, figsize=None, **kwargs):
     if not figsize:

--- a/model_demos/nlp_demos/falcon/utils/pybudify.py
+++ b/model_demos/nlp_demos/falcon/utils/pybudify.py
@@ -53,9 +53,9 @@ class PyBudify(torch.nn.Module):
 
             # pybuda workarounds
             os.environ["GOLDEN_WORMHOLE_B0"] = "1"  # golden should always simulate a B0 as that's all we use now
-            os.environ[
-                "PYBUDA_ENABLE_STABLE_SOFTMAX"
-            ] = "1"  # improved accuracy - pybuda team surprised we need it though
+            os.environ["PYBUDA_ENABLE_STABLE_SOFTMAX"] = (
+                "1"  # improved accuracy - pybuda team surprised we need it though
+            )
             os.environ["PYBUDA_CONVERT_PARAMS_TO_TVM"] = "0"  # faster compile times... why would this ever be 1?
             os.environ["TT_BACKEND_TIMEOUT"] = "0"  # default is too aggressive for large models?
 

--- a/model_demos/nlp_demos/falcon/utils/tt_modeling_RW_pad_masked_odkv.py
+++ b/model_demos/nlp_demos/falcon/utils/tt_modeling_RW_pad_masked_odkv.py
@@ -834,12 +834,12 @@ class DecoderLayer(nn.Module):
 
         # replace mlp with padded
         padded_mlp = PaddedMLP(self.config)
-        padded_mlp.dense_h_to_4h.weight.data[
-            : 4 * unpadded_hidden, :unpadded_hidden
-        ] = self.mlp.dense_h_to_4h.weight.data
-        padded_mlp.dense_4h_to_h.weight.data[
-            :unpadded_hidden, : 4 * unpadded_hidden
-        ] = self.mlp.dense_4h_to_h.weight.data
+        padded_mlp.dense_h_to_4h.weight.data[: 4 * unpadded_hidden, :unpadded_hidden] = (
+            self.mlp.dense_h_to_4h.weight.data
+        )
+        padded_mlp.dense_4h_to_h.weight.data[:unpadded_hidden, : 4 * unpadded_hidden] = (
+            self.mlp.dense_4h_to_h.weight.data
+        )
         padded_mlp.make_pad_weights()
         self.mlp = padded_mlp
 
@@ -1280,7 +1280,7 @@ class RWModel(RWPreTrainedModel):
 
         if past_key_values is not None and attention_mask is not None:
             flattened_kv = []
-            for (k, v) in past_key_values:
+            for k, v in past_key_values:
                 flattened_kv.extend([k, v])
             # outputs = self.blocks(hidden_states, cos, sin, attention_mask, *flattened_kv)
             # import pdb; pdb.set_trace()

--- a/model_demos/requirements-dev.txt
+++ b/model_demos/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest==7.1.2
-black==22.3.0
+black==24.4.0
 flake8==3.9.2
 isort==5.10.1
 pre-commit==2.19.0


### PR DESCRIPTION
Versions of the package black before 24.3.0 are vulnerable to Regular Expression Denial of Service (ReDoS) via the lines_with_leading_tabs_expanded function in the strings.py file. An attacker could exploit this vulnerability by crafting a malicious input that causes a denial of service.