### PR TITLE
Add demo scripts for ssd300resnet50 and yolov6 (pytorch)

### DIFF
--- a/model_demos/README.md
+++ b/model_demos/README.md
@@ -65,6 +65,7 @@ python cv_demos/resnet/pytorch_resnet.py
 |   [ResNet](cv_demos/resnet/)                                 |     GS, WH   | v0.10.5 |
 |   [ResNeXt](cv_demos/resnext/)                               |     GS, WH   | v0.10.5 |
 |   [RetinaNet](cv_demos/retinanet/)                           |     GS, WH   | v0.10.5 |
+|   [SSD300RESNET50](cv_demos/ssd300_resnet50/)                |     GS, WH   |   TBD   |
 |   [RoBERTa](nlp_demos/roberta/)                              |     GS, WH   | v0.10.5 |
 |   [SqueezeBERT](nlp_demos/squeezebert/)                      |     GS, WH   | v0.10.5 |
 |   [Stable Diffusion](cv_demos/stable_diffusion/)             |         WH   | v0.10.5 |
@@ -80,6 +81,7 @@ python cv_demos/resnet/pytorch_resnet.py
 |   [XGLM](nlp_demos/xglm/)                                    |     GS, WH   | v0.10.5 |
 |   [YOLOv3](cv_demos/yolo_v3/)                                |     GS, WH   | v0.10.5 |
 |   [YOLOv5](cv_demos/yolo_v5/)                                |     GS, WH   | v0.10.5 |
+|   [YOLOv6](cv_demos/yolo_v6/)                                |     GS, WH   |   TBD   |
 
 
 ## Note:

--- a/model_demos/cv_demos/ssd300_resnet50/pytorch_ssd300_resnet50.py
+++ b/model_demos/cv_demos/ssd300_resnet50/pytorch_ssd300_resnet50.py
@@ -1,0 +1,131 @@
+# ssd300_resnet50 demo script
+
+import pybuda
+import numpy as np
+import torch
+import os
+import skimage
+import requests
+from pybuda._C.backend_api import BackendDevice
+
+
+# preprocessing scripts referred from https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/Detection/SSD/examples/SSD300_inference.py
+
+
+def load_image(image_path):
+    """Code from Loading_Pretrained_Models.ipynb - a Caffe2 tutorial"""
+    mean, std = 128, 128
+    img = skimage.img_as_float(skimage.io.imread(image_path))
+    if len(img.shape) == 2:
+        img = np.array([img, img, img]).swapaxes(0, 2)
+    return img
+
+
+def rescale(img, input_height, input_width):
+    """Code from Loading_Pretrained_Models.ipynb - a Caffe2 tutorial"""
+    aspect = img.shape[1] / float(img.shape[0])
+    if aspect > 1:
+        # landscape orientation - wide image
+        res = int(aspect * input_height)
+        imgScaled = skimage.transform.resize(img, (input_width, res))
+    if aspect < 1:
+        # portrait orientation - tall image
+        res = int(input_width / aspect)
+        imgScaled = skimage.transform.resize(img, (res, input_height))
+    if aspect == 1:
+        imgScaled = skimage.transform.resize(img, (input_width, input_height))
+    return imgScaled
+
+
+def crop_center(img, cropx, cropy):
+    """Code from Loading_Pretrained_Models.ipynb - a Caffe2 tutorial"""
+    y, x, c = img.shape
+    startx = x // 2 - (cropx // 2)
+    starty = y // 2 - (cropy // 2)
+    return img[starty : starty + cropy, startx : startx + cropx]
+
+
+def normalize(img, mean=128, std=128):
+    img = (img * 256 - mean) / std
+    return img
+
+
+def prepare_input(img_uri):
+    img = load_image(img_uri)
+    img = rescale(img, 300, 300)
+    img = crop_center(img, 300, 300)
+    img = normalize(img)
+    return img
+
+
+def run_pytorch_ssd300_resnet50():
+
+    # STEP 1 : Set PyBuda configuration parameters
+    compiler_cfg = pybuda.config._get_global_compiler_config()
+    compiler_cfg.balancer_policy = "Ribbon"
+    compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
+    compiler_cfg.amp_level = 1
+
+    # Device specific configurations
+    available_devices = pybuda.detect_available_devices()
+    if available_devices:
+        if available_devices[0] == BackendDevice.Grayskull:
+            os.environ["PYBUDA_RIBBON2"] = "1"
+            os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "90112"
+
+        if available_devices[0] == BackendDevice.Wormhole_B0:
+            compiler_cfg.place_on_new_epoch("conv2d_766.dc.matmul.11")
+            os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "45056"
+
+    # STEP 2 : prepare model
+    model = torch.hub.load("NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd", pretrained=False)
+    url = "https://api.ngc.nvidia.com/v2/models/nvidia/ssd_pyt_ckpt_amp/versions/19.09.0/files/nvidia_ssdpyt_fp16_190826.pt"
+    checkpoint_path = "nvidia_ssdpyt_fp16_190826.pt"
+
+    response = requests.get(url)
+    with open(checkpoint_path, "wb") as f:
+        f.write(response.content)
+
+    checkpoint = torch.load(checkpoint_path, map_location=torch.device("cpu"))
+    model.load_state_dict(checkpoint["model"])
+    model.eval()
+    tt_model = pybuda.PyTorchModule("pt_ssd300_resnet50", model)
+
+    # STEP 3 : prepare input
+    img = "http://images.cocodataset.org/val2017/000000397133.jpg"
+    HWC = prepare_input(img)
+    CHW = np.swapaxes(np.swapaxes(HWC, 0, 2), 1, 2)
+    batch = np.expand_dims(CHW, axis=0)
+    input_batch = torch.from_numpy(batch).float()
+
+    # STEP 4 : Inference
+    output_q = pybuda.run_inference(tt_model, inputs=([input_batch]))
+    output = output_q.get()
+
+    for i in range(len(output)):
+        output[i] = output[i].value()
+
+    # postprocessing scripts referred from https://pytorch.org/hub/nvidia_deeplearningexamples_ssd/
+
+    # STEP 5 : Postprocess
+    utils = torch.hub.load("NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd_processing_utils")
+    classes_to_labels = utils.get_coco_object_dictionary()
+    results_per_input = utils.decode_results(output)
+    best_results_per_input = [utils.pick_best(results, 0.40) for results in results_per_input]
+
+    for image_idx in range(len(best_results_per_input)):
+        bboxes, classes, confidences = best_results_per_input[image_idx]
+        for idx in range(len(bboxes)):
+            left, bot, right, top = bboxes[idx]
+            x, y, w, h = [val * 300 for val in [left, bot, right - left, top - bot]]
+            box_info = f"Co-ordinates: [{left:.2f}, {bot:.2f}, {right:.2f}, {top:.2f}]"
+            class_info = f"Class: {classes_to_labels[classes[idx] - 1]}"
+            confidence_info = f"Confidence: {confidences[idx]*100:.2f}%"
+            print(f"{box_info}, {class_info}, {confidence_info}")
+
+    # STEP 6 : remove the downloaded weights
+    os.remove(checkpoint_path)
+
+
+if __name__ == "__main__":
+    run_pytorch_ssd300_resnet50()

--- a/model_demos/cv_demos/yolo_v6/pytorch_yolov6.py
+++ b/model_demos/cv_demos/yolo_v6/pytorch_yolov6.py
@@ -1,0 +1,186 @@
+# yolo_v6 demo script
+
+import pybuda
+import os
+import requests
+import math
+import cv2
+import numpy as np
+import torch
+from PIL import Image
+from yolov6 import YOLOV6
+from yolov6.utils.nms import non_max_suppression
+from yolov6.core.inferer import Inferer
+from yolov6.utils.events import load_yaml
+from pybuda._C.backend_api import BackendDevice
+
+# preprocessing & postprocessing steps referred form https://github.com/meituan/YOLOv6/blob/main/inference.ipynb
+
+
+def letterbox(im, new_shape=(640, 640), color=(114, 114, 114), auto=True, scaleup=True, stride=32):
+    """Resize and pad image while meeting stride-multiple constraints."""
+    shape = im.shape[:2]  # current shape [height, width]
+    if isinstance(new_shape, int):
+        new_shape = (new_shape, new_shape)
+    elif isinstance(new_shape, list) and len(new_shape) == 1:
+        new_shape = (new_shape[0], new_shape[0])
+
+    # Scale ratio (new / old)
+    r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+    if not scaleup:  # only scale down, do not scale up (for better val mAP)
+        r = min(r, 1.0)
+
+    # Compute padding
+    new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
+    dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]  # wh padding
+
+    if auto:  # minimum rectangle
+        dw, dh = np.mod(dw, stride), np.mod(dh, stride)  # wh padding
+
+    dw /= 2  # divide padding into 2 sides
+    dh /= 2
+
+    if shape[::-1] != new_unpad:  # resize
+        im = cv2.resize(im, new_unpad, interpolation=cv2.INTER_LINEAR)
+    top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
+    left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
+    im = cv2.copyMakeBorder(im, top, bottom, left, right, cv2.BORDER_CONSTANT, value=color)  # add border
+
+    return im, r, (left, top)
+
+
+def check_img_size(img_size, s=32, floor=0):
+    def make_divisible(x, divisor):
+        # Upward revision the value x to make it evenly divisible by the divisor.
+        return math.ceil(x / divisor) * divisor
+
+    """Make sure image size is a multiple of stride s in each dimension, and return a new shape list of image."""
+    if isinstance(img_size, int):  # integer i.e. img_size=640
+        new_size = max(make_divisible(img_size, int(s)), floor)
+    elif isinstance(img_size, list):  # list i.e. img_size=[640, 480]
+        new_size = [max(make_divisible(x, int(s)), floor) for x in img_size]
+    else:
+        raise Exception(f"Unsupported type of img_size: {type(img_size)}")
+
+    if new_size != img_size:
+        print(f"WARNING: --img-size {img_size} must be multiple of max stride {s}, updating to {new_size}")
+    return new_size if isinstance(img_size, list) else [new_size] * 2
+
+
+def process_image(path, img_size, stride, half):
+    """Process image before image inference."""
+
+    img_src = np.asarray(Image.open(requests.get(path, stream=True).raw))
+    image = letterbox(img_src, img_size, stride=stride)[0]
+    # Convert
+    image = image.transpose((2, 0, 1))  # HWC to CHW
+    image = torch.from_numpy(np.ascontiguousarray(image))
+    image = image.half() if half else image.float()  # uint8 to fp16/32
+    image /= 255  # 0 - 255 to 0.0 - 1.0
+
+    return image, img_src
+
+
+def run_yolov6_pytorch(variant):
+
+    # STEP 1 : Set PyBuda configuration parameters
+    compiler_cfg = pybuda.config._get_global_compiler_config()
+    compiler_cfg.balancer_policy = "Ribbon"
+    os.environ["PYBUDA_RIBBON2"] = "1"
+    compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
+
+    if variant in ["yolov6m", "yolov6l"]:
+        os.environ["PYBUDA_FORK_JOIN_BUF_QUEUES"] = "1"
+        os.environ["PYBUDA_FORK_JOIN_EXPAND_OUTPUT_BUFFERS"] = "1"
+        os.environ["PYBUDA_FORK_JOIN_SKIP_EXPANDING_BUFFERS"] = "1"
+        os.environ["PYBUDA_MAX_FORK_JOIN_BUF"] = "1"
+
+        # Device specific configurations
+        available_devices = pybuda.detect_available_devices()
+        if available_devices:
+            if available_devices[0] == BackendDevice.Grayskull and variant == "yolov6m":
+                compiler_cfg.balancer_op_override(
+                    "conv2d_258.dc.reshape.0.dc.sparse_matmul.4.lc2", "grid_shape", (1, 1)
+                )
+                compiler_cfg.balancer_op_override(
+                    "conv2d_258.dc.reshape.12.dc.sparse_matmul.3.lc2",
+                    "t_stream_shape",
+                    (2, 1),
+                )
+
+            if available_devices[0] == BackendDevice.Wormhole_B0 and variant == "yolov6l":
+                os.environ["PYBUDA_FORCE_CONV_MULTI_OP_FRACTURE"] = "1"
+
+            if available_devices[0] == BackendDevice.Grayskull and variant == "yolov6l":
+                compiler_cfg.balancer_op_override(
+                    "conv2d_484.dc.reshape.0.dc.sparse_matmul.4.lc2", "grid_shape", (1, 1)
+                )
+                compiler_cfg.balancer_op_override(
+                    "conv2d_484.dc.reshape.12.dc.sparse_matmul.3.lc2",
+                    "t_stream_shape",
+                    (2, 1),
+                )
+
+    # STEP 2 :prepare model
+    url = f"https://github.com/meituan/YOLOv6/releases/download/0.3.0/{variant}.pt"
+    weights = f"{variant}.pt"
+
+    try:
+        response = requests.get(url)
+        with open(weights, "wb") as file:
+            file.write(response.content)
+        print(f"Downloaded {url} to {weights}")
+    except Exception as e:
+        print(f"Error downloading {url}: {e}")
+
+    model = YOLOV6(weights)
+    model = model.model
+    model.eval()
+
+    tt_model = pybuda.PyTorchModule(f"pt_{variant}", model)
+
+    # STEP 3 : prepare input
+    url = "http://images.cocodataset.org/val2017/000000397133.jpg"
+    stride = 32
+    input_size = 640
+    img_size = check_img_size(input_size, s=stride)
+    img, img_src = process_image(url, img_size, stride, half=False)
+    input_batch = img.unsqueeze(0)
+
+    # STEP 4 : Inference
+    output_q = pybuda.run_inference(tt_model, inputs=([input_batch]))
+    output = output_q.get()[0].value()
+
+    # STEP 5 : Postprocess
+    det = non_max_suppression(output)[0]
+
+    # Send a GET request to fetch the YAML file
+    response = requests.get("https://github.com/meituan/YOLOv6/raw/main/data/coco.yaml")
+
+    with open("coco.yaml", "wb") as file:
+        # Write the content to the file
+        file.write(response.content)
+
+    class_names = load_yaml("coco.yaml")["names"]
+
+    if len(det):
+        det[:, :4] = Inferer.rescale(input_batch.shape[2:], det[:, :4], img_src.shape).round()
+
+        for *xyxy, conf, cls in reversed(det):
+            class_num = int(cls)  # Convert class index to integer
+            conf_value = conf.item()  # Get the confidence value
+            coordinates = [int(x.item()) for x in xyxy]  # Convert tensor to list of integers
+
+            # Get the class label
+            label = class_names[class_num]
+
+            # Detections
+            print(f"Coordinates: {coordinates}, Class: {label}, Confidence: {conf_value:.2f}")
+
+    # STEP 6 : remove downloaded weights and YAML file
+    os.remove(weights)
+    os.remove("coco.yaml")
+
+
+if __name__ == "__main__":
+    run_yolov6_pytorch()

--- a/model_demos/pyproject.toml
+++ b/model_demos/pyproject.toml
@@ -83,4 +83,6 @@ markers = [
     "perceiverio: tests that involve Perceiver IO",
     "hardnet: tests that involve hardnet",
     "fpn: tests that involve FPN",
+    "ssd300_resnet50: tests that involve ssd300_resnet50",
+    "yolov6: tests that involve yolov6",
 ]

--- a/model_demos/requirements.txt
+++ b/model_demos/requirements.txt
@@ -9,3 +9,4 @@ soundfile==0.12.1  # For Whisper
 librosa==0.10.0  # For Whisper
 segmentation-models-pytorch==0.3.3  # For U-Net
 diffusers==0.14.0  # For Stable Diffusion
+yolov6detect==0.4.1 # For YOLOv6

--- a/model_demos/tests/test_pytorch_ssd300_resnet50.py
+++ b/model_demos/tests/test_pytorch_ssd300_resnet50.py
@@ -1,0 +1,8 @@
+import pytest
+
+from cv_demos.ssd300_resnet50.pytorch_ssd300_resnet50 import run_pytorch_ssd300_resnet50
+
+
+@pytest.mark.ssd300_resnet50
+def test_ssd300_resnet50_pytorch(clear_pybuda):
+    run_pytorch_ssd300_resnet50()

--- a/model_demos/tests/test_pytorch_yolov6.py
+++ b/model_demos/tests/test_pytorch_yolov6.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cv_demos.yolo_v6.pytorch_yolov6 import run_yolov6_pytorch
+
+
+variants = ["yolov6n", "yolov6s", "yolov6m", "yolov6l"]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.yolov6
+def test_yolov6_pytorch(variant, clear_pybuda):
+    run_yolov6_pytorch(variant)


### PR DESCRIPTION
Demo scripts Added for the following models in pytorch
1.  SSD300RESNET50
2. YOLOV6 
    - Supported variants : YOLOV6-N, YOLOV6-S, YOLOV6-M, YOLOV6-L
    - Didn't dealt with YOLOV6-N6, YOLOV6-S6, YOLOV6-M6, YOLOV6-L6 variants due to its higher input size (1280)
    