### PR TITLE
#0: Add pre- and post- processing to DLA demo

### DIFF
--- a/model_demos/cv_demos/dla/pytorch_dla.py
+++ b/model_demos/cv_demos/dla/pytorch_dla.py
@@ -1,22 +1,24 @@
-import pybuda
-from pybuda._C.backend_api import BackendDevice
-
 import os
-import torch
+import urllib
+
+import pybuda
+import requests
+import torchvision.transforms as transforms
+from PIL import Image
+from pybuda._C.backend_api import BackendDevice
 
 from cv_demos.dla.utils.model import (
     dla34,
     dla46_c,
     dla46x_c,
-    dla60x_c,
     dla60,
     dla60x,
+    dla60x_c,
     dla102,
     dla102x,
     dla102x2,
     dla169,
 )
-
 
 variants_func = {
     "dla34": dla34,
@@ -33,13 +35,16 @@ variants_func = {
 
 
 def run_dla_pytorch(variant):
-    # PyBuda configuration parameters
+
+    # Load model function
+    func = variants_func[variant]
+    model_name = f"dla_{func.__name__}_pytorch"
+
+    # Set PyBuda configuration parameters
     compiler_cfg = pybuda.config._get_global_compiler_config()
     compiler_cfg.balancer_policy = "Ribbon"
     compiler_cfg.default_df_override = pybuda._C.Float16_b
     os.environ["PYBUDA_RIBBON2"] = "1"
-
-    func = variants_func[variant]
 
     available_devices = pybuda.detect_available_devices()
     if available_devices:
@@ -53,9 +58,23 @@ def run_dla_pytorch(variant):
             elif func.__name__ == "dla60x":
                 os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "20480"
 
-    model_name = f"dla_{func.__name__}_pytorch"
-    input = torch.randn(1, 3, 384, 1280)
+    # Load data sample
+    url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    label = "tiger"
 
+    # Preprocessing
+    transform = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+    img_tensor = transform(image).unsqueeze(0)
+
+    # Load model and prepare for evaluation (inference)
     pytorch_model = func(pretrained="imagenet")
     pytorch_model.eval()
 
@@ -63,6 +82,21 @@ def run_dla_pytorch(variant):
     tt_model = pybuda.PyTorchModule(model_name, pytorch_model)
 
     # run inference on Tenstorrent device
-    output_q = pybuda.run_inference(tt_model, inputs=[(input,)])
+    output_q = pybuda.run_inference(tt_model, inputs=[(img_tensor,)])
     output = output_q.get()[0].value()
-    print(output)
+
+    # Get ImageNet class mappings
+    url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"
+    image_classes = urllib.request.urlopen(url)
+    categories = [s.decode("utf-8").strip() for s in image_classes.readlines()]
+
+    # Post processing
+    predicted_value = output.argmax(-1).item()
+    predicted_label = categories[predicted_value]
+
+    # Print outputs
+    print(f"True Label: {label} | Predicted Label: {predicted_label}")
+
+
+if __name__ == "__main__":
+    run_dla_pytorch("dla34")

--- a/model_demos/cv_demos/dla/utils/model.py
+++ b/model_demos/cv_demos/dla/utils/model.py
@@ -37,20 +37,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 
+import math
+from collections import namedtuple
 from os.path import join
 
-import math
 import torch
-from torch import nn
 import torch.utils.model_zoo as model_zoo
-from collections import namedtuple
-
+from torch import nn
 
 BatchNorm = nn.BatchNorm2d
 WEB_ROOT = "http://dl.yf.io/dla/models"
-Dataset = namedtuple(
-    "Dataset", ["model_hash", "classes", "mean", "std", "eigval", "eigvec", "name"]
-)
+Dataset = namedtuple("Dataset", ["model_hash", "classes", "mean", "std", "eigval", "eigvec", "name"])
 imagenet = Dataset(
     name="imagenet",
     classes=1000,
@@ -85,9 +82,7 @@ def get_model_url(data, name):
 
 def conv3x3(in_planes, out_planes, stride=1):
     "3x3 convolution with padding"
-    return nn.Conv2d(
-        in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False
-    )
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False)
 
 
 class BasicBlock(nn.Module):
@@ -308,9 +303,7 @@ class Tree(nn.Module):
             self.downsample = nn.MaxPool2d(stride, stride=stride)
         if in_channels != out_channels:
             self.project = nn.Sequential(
-                nn.Conv2d(
-                    in_channels, out_channels, kernel_size=1, stride=1, bias=False
-                ),
+                nn.Conv2d(in_channels, out_channels, kernel_size=1, stride=1, bias=False),
                 BatchNorm(out_channels),
             )
 
@@ -352,9 +345,7 @@ class DLA(nn.Module):
             nn.ReLU(inplace=True),
         )
         self.level0 = self._make_conv_level(channels[0], channels[0], levels[0])
-        self.level1 = self._make_conv_level(
-            channels[0], channels[1], levels[1], stride=2
-        )
+        self.level1 = self._make_conv_level(channels[0], channels[1], levels[1], stride=2)
         self.level2 = Tree(
             levels[2],
             block,
@@ -393,9 +384,7 @@ class DLA(nn.Module):
         )
 
         self.avgpool = nn.AvgPool2d(pool_size)
-        self.fc = nn.Conv2d(
-            channels[-1], num_classes, kernel_size=1, stride=1, padding=0, bias=True
-        )
+        self.fc = nn.Conv2d(channels[-1], num_classes, kernel_size=1, stride=1, padding=0, bias=True)
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
@@ -478,9 +467,7 @@ class DLA(nn.Module):
 
 
 def dla34(pretrained=None, **kwargs):  # DLA-34
-    model = DLA(
-        [1, 1, 1, 2, 2, 1], [16, 32, 64, 128, 256, 512], block=BasicBlock, **kwargs
-    )
+    model = DLA([1, 1, 1, 2, 2, 1], [16, 32, 64, 128, 256, 512], block=BasicBlock, **kwargs)
     if pretrained is not None:
         model.load_pretrained_model(pretrained, "dla34")
     return model
@@ -488,9 +475,7 @@ def dla34(pretrained=None, **kwargs):  # DLA-34
 
 def dla46_c(pretrained=None, **kwargs):  # DLA-46-C
     Bottleneck.expansion = 2
-    model = DLA(
-        [1, 1, 1, 2, 2, 1], [16, 32, 64, 64, 128, 256], block=Bottleneck, **kwargs
-    )
+    model = DLA([1, 1, 1, 2, 2, 1], [16, 32, 64, 64, 128, 256], block=Bottleneck, **kwargs)
     if pretrained is not None:
         model.load_pretrained_model(pretrained, "dla46_c")
     return model
@@ -498,9 +483,7 @@ def dla46_c(pretrained=None, **kwargs):  # DLA-46-C
 
 def dla46x_c(pretrained=None, **kwargs):  # DLA-X-46-C
     BottleneckX.expansion = 2
-    model = DLA(
-        [1, 1, 1, 2, 2, 1], [16, 32, 64, 64, 128, 256], block=BottleneckX, **kwargs
-    )
+    model = DLA([1, 1, 1, 2, 2, 1], [16, 32, 64, 64, 128, 256], block=BottleneckX, **kwargs)
     if pretrained is not None:
         model.load_pretrained_model(pretrained, "dla46x_c")
     return model
@@ -508,9 +491,7 @@ def dla46x_c(pretrained=None, **kwargs):  # DLA-X-46-C
 
 def dla60x_c(pretrained=None, **kwargs):  # DLA-X-60-C
     BottleneckX.expansion = 2
-    model = DLA(
-        [1, 1, 1, 2, 3, 1], [16, 32, 64, 64, 128, 256], block=BottleneckX, **kwargs
-    )
+    model = DLA([1, 1, 1, 2, 3, 1], [16, 32, 64, 64, 128, 256], block=BottleneckX, **kwargs)
     if pretrained is not None:
         model.load_pretrained_model(pretrained, "dla60x_c")
     return model
@@ -518,9 +499,7 @@ def dla60x_c(pretrained=None, **kwargs):  # DLA-X-60-C
 
 def dla60(pretrained=None, **kwargs):  # DLA-60
     Bottleneck.expansion = 2
-    model = DLA(
-        [1, 1, 1, 2, 3, 1], [16, 32, 128, 256, 512, 1024], block=Bottleneck, **kwargs
-    )
+    model = DLA([1, 1, 1, 2, 3, 1], [16, 32, 128, 256, 512, 1024], block=Bottleneck, **kwargs)
     if pretrained is not None:
         model.load_pretrained_model(pretrained, "dla60")
     return model
@@ -528,9 +507,7 @@ def dla60(pretrained=None, **kwargs):  # DLA-60
 
 def dla60x(pretrained=None, **kwargs):  # DLA-X-60
     BottleneckX.expansion = 2
-    model = DLA(
-        [1, 1, 1, 2, 3, 1], [16, 32, 128, 256, 512, 1024], block=BottleneckX, **kwargs
-    )
+    model = DLA([1, 1, 1, 2, 3, 1], [16, 32, 128, 256, 512, 1024], block=BottleneckX, **kwargs)
     if pretrained is not None:
         model.load_pretrained_model(pretrained, "dla60x")
     return model

--- a/model_demos/tests/test_pytorch_dla.py
+++ b/model_demos/tests/test_pytorch_dla.py
@@ -1,6 +1,6 @@
 import pytest
-from cv_demos.dla.pytorch_dla import run_dla_pytorch
 
+from cv_demos.dla.pytorch_dla import run_dla_pytorch
 
 variants = [
     "dla34",


### PR DESCRIPTION
Adding pre- and post-processing functions for the DLA demo.

The model task used in the demo is for image classification (as trained on the ImageNet dataset) following the guide from: https://github.com/ucbdrive/dla/blob/master/classify.py

@nvukobratTT **Important note:** The original demo used input shape of (1, 3, 384, 1280) but for the image classification task the input should be (1, 3, 224, 224) as defined by the trained data. All variants need to be tested.

For extracting the pre and post processing steps, these were the references used:
- https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/densenet/pytorch_densenet.py#L16
- https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/resnet/pytorch_resnet.py#L38
- https://github.com/ucbdrive/dla/blob/master/classify.py#L152