### PR TITLE
Patch SSD300-RESNET50's CI failures

### DIFF
--- a/model_demos/cv_demos/ssd300_resnet50/pytorch_ssd300_resnet50.py
+++ b/model_demos/cv_demos/ssd300_resnet50/pytorch_ssd300_resnet50.py
@@ -71,7 +71,7 @@ def run_pytorch_ssd300_resnet50():
     if available_devices:
         if available_devices[0] == BackendDevice.Grayskull:
             os.environ["PYBUDA_RIBBON2"] = "1"
-            os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "90112"
+            compiler_cfg.balancer_op_override("max_pool2d_14.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (2, 1))
 
         if available_devices[0] == BackendDevice.Wormhole_B0:
             compiler_cfg.place_on_new_epoch("conv2d_766.dc.matmul.11")
@@ -104,6 +104,8 @@ def run_pytorch_ssd300_resnet50():
 
     for i in range(len(output)):
         output[i] = output[i].value()
+
+    output = [o.detach().clone() for o in output]
 
     # postprocessing scripts referred from https://pytorch.org/hub/nvidia_deeplearningexamples_ssd/
 


### PR DESCRIPTION
**N150 - golden**

- **Failed Job** - customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-wh-b0-n150-golden
- **Job link** - [https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/5949997](url)
- **Error** - RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation.
- **Cause** - In-place operation was attempted on a tensor that is a "leaf" variable (a tensor that requires gradients and is at the start of the computation graph
- **Fix** - output = [o.detach().clone() for o in output] 
- **explanation** - After applying detach() and clone(), the new tensor is not part of the computation graph and does not require gradients. Therefore, it is safe to perform in-place operations on it without affecting the gradient computations or causing errors
- **After fix** - [N150_compute.log](https://github.com/tenstorrent/tt-buda-demos/files/15390546/N150_compute.log)


**E150,E300 -golden, E150,E300 -silicon**

  **Failed jobs and it's link** 
  
  - customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-gs-e150-golden - [Link](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/5949985) 
  - customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-gs-e300-golden  - [Link ](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/5949990)
  - customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-gs-e150-silicon  - [Link](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/5950014) 
  - customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-gs-e300-silicon  - [Link](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/5950032)
  
  **Error** - pipegen error
  
  **Fix** - override problematic op with low t-stream shape
  
   **After fix** -
  
  - [E150_compute.log](https://github.com/tenstorrent/tt-buda-demos/files/15390601/E150_compute.log)
  - [E150_silicon.log](https://github.com/tenstorrent/tt-buda-demos/files/15390602/E150_silicon.log)
  - [E300_compute.log](https://github.com/tenstorrent/tt-buda-demos/files/15390603/E300_compute.log)
  - [E300_silicon.log](https://github.com/tenstorrent/tt-buda-demos/files/15390604/E300_silicon.log)





