### PR TITLE
Adjust import path in model script

### DIFF
--- a/model_demos/cv_demos/retinanet/model/model_implementation.py
+++ b/model_demos/cv_demos/retinanet/model/model_implementation.py
@@ -37,8 +37,7 @@ import torch
 import torch.nn as nn
 import sys
 
-sys.path.append("cv_demos/retinanet/model/")
-import backbone as backbones_mod
+import cv_demos.retinanet.model.backbone as backbones_mod
 import torch.nn.functional as F
 
 


### PR DESCRIPTION
Adjusting import path in model script as old one causes below error during generating yaml configurations

```
_______________ ERROR collecting tests/test_pytorch_retinanet.py _______________
ImportError while importing test module '/proj_sw/user_dev/kkannan/may23_retinanet_CI_config/pybuda/third_party/buda-model-demos/model_demos/tests/test_pytorch_retinanet.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
third_party/buda-model-demos/model_demos/tests/test_pytorch_retinanet.py:2: in <module>
    from cv_demos.retinanet.pytorch_retinanet import run_retinanet_pytorch
third_party/buda-model-demos/model_demos/cv_demos/retinanet/pytorch_retinanet.py:8: in <module>
    from cv_demos.retinanet.model.model_implementation import Model
third_party/buda-model-demos/model_demos/cv_demos/retinanet/model/model_implementation.py:41: in <module>
    import backbone as backbones_mod
E   ModuleNotFoundError: No module named 'backbone'
```
