### PR TITLE
Patch transformers library upgrade CI failures

### DIFF
--- a/model_demos/cv_demos/stable_diffusion/pytorch_stable_diffusion.py
+++ b/model_demos/cv_demos/stable_diffusion/pytorch_stable_diffusion.py
@@ -113,6 +113,8 @@ def initialize_compiler_overrides():
     os.environ["PYBUDA_FORCE_CONV_MULTI_OP_FRACTURE"] = "1"
     os.environ["PYBUDA_RIBBON2"] = "1"
     os.environ["PYBUDA_DECOMPOSE_SIGMOID"] = "1"
+    os.environ["PYBUDA_DRAM_PICK_CAPACITY"]="1"
+    os.environ["PYBUDA_DRAM_FLIP_FLOP"]="1"
 
     compiler_cfg = pybuda.config._get_global_compiler_config()
     compiler_cfg.enable_tvm_constant_prop = True

--- a/model_demos/nlp_demos/falcon/utils/model.py
+++ b/model_demos/nlp_demos/falcon/utils/model.py
@@ -8,7 +8,6 @@ import pybuda
 import torch
 from torch.nn import functional as F
 from transformers import AutoTokenizer
-from transformers.generation.utils import top_k_top_p_filtering
 
 from nlp_demos.falcon.utils.configuration_RW import RWConfig
 from nlp_demos.falcon.utils.pybudify import PyBudify
@@ -264,6 +263,45 @@ class Falcon:
 
         return all_output
 
+def top_k_top_p_filtering(
+    logits: torch.Tensor,
+    top_k: int = 0,
+    top_p: float = 1.0,
+    filter_value: float = -float("Inf"),
+    min_tokens_to_keep: int = 1,
+) -> torch.Tensor:
+    """Filter a distribution of logits using top-k and/or nucleus (top-p) filtering
+    Args:
+        logits: logits distribution shape (batch size, vocabulary size)
+        if top_k > 0: keep only top k tokens with highest probability (top-k filtering).
+        if top_p < 1.0: keep the top tokens with cumulative probability >= top_p (nucleus filtering).
+            Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751)
+        Make sure we keep at least min_tokens_to_keep per batch example in the output
+    From: https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf317
+    """
+    if top_k > 0:
+        top_k = min(max(top_k, min_tokens_to_keep), logits.size(-1))  # Safety check
+        # Remove all tokens with a probability less than the last token of the top-k
+        indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
+        logits[indices_to_remove] = filter_value
+
+    if top_p < 1.0:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+        cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
+
+        # Remove tokens with cumulative probability above the threshold (token with 0 are kept)
+        sorted_indices_to_remove = cumulative_probs > top_p
+        if min_tokens_to_keep > 1:
+            # Keep at least min_tokens_to_keep (set to min_tokens_to_keep-1 because we add the first one below)
+            sorted_indices_to_remove[..., :min_tokens_to_keep] = 0
+        # Shift the indices to the right to keep also the first token above the threshold
+        sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
+        sorted_indices_to_remove[..., 0] = 0
+
+        # scatter sorted tensors to original indexing
+        indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
+        logits[indices_to_remove] = filter_value
+    return logits
 
 def sample_kp_logits(logits, k, p):
     next_token_logscores = top_k_top_p_filtering(logits, top_k=k, top_p=p)


### PR DESCRIPTION
### Update transformers from 4.35.2 to 4.41.0

Customer Demos Weekly Pipeline 1 - [https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/pipelines/493859](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/pipelines/493859)
Customer Demos Weekly Pipeline 2 - [https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/pipelines/494906](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/pipelines/494906 )

Customer Demos Weekly Pipeline sheet 1- [https://docs.google.com/spreadsheets/d/1BTqfQ-WwHrG6U0actBF296YI3OABjjhKWRfktnKn_Mc/edit#gid=884659698](https://docs.google.com/spreadsheets/d/1BTqfQ-WwHrG6U0actBF296YI3OABjjhKWRfktnKn_Mc/edit#gid=884659698)
Customer Demos Weekly Pipeline sheet 2 - [https://docs.google.com/spreadsheets/d/1BTqfQ-WwHrG6U0actBF296YI3OABjjhKWRfktnKn_Mc/edit#gid=1314094743](https://docs.google.com/spreadsheets/d/1BTqfQ-WwHrG6U0actBF296YI3OABjjhKWRfktnKn_Mc/edit#gid=1314094743)


**Failures**
**Import issues**
Job - [customer-pytorch-falcon-falcon-pytorch-wh-b0-n150-silicon](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6014905)
Error - ImportError: cannot import name 'top_k_top_p_filtering' from 'transformers.generation.utils'

**DRAM issues**
Jobs - [customer-pytorch-stable-diffusion-stable-diffusion-pytorch-wh-b0-n150-silicon](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6015004) , [customer-pytorch-stable-diffusion-stable-diffusion-pytorch-wh-b0-n150-golden](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6014237)
Error - DRAM IO queue const_00 (addr: 0x2663e60) must be above reserved space ending at: 0x30d0000 for channel 0
