### PR TITLE
patch CI failures for tt_buda_demos Stabilization(30/6/24)

### DIFF
--- a/model_demos/cv_demos/inception_v4/pytorch_inception_v4_osmr.py
+++ b/model_demos/cv_demos/inception_v4/pytorch_inception_v4_osmr.py
@@ -53,6 +53,7 @@ def run_inception_v4_osmr_pytorch():
     if pybuda.detect_available_devices()[0] == BackendDevice.Grayskull:
         compiler_cfg.balancer_op_override("_fused_op_2", "t_stream_shape", (676, 1))  # TM error (ref pybuda#1527)
     elif pybuda.detect_available_devices()[0] == BackendDevice.Wormhole_B0:
+        compiler_cfg.balancer_op_override("_fused_op_2", "t_stream_shape", (676, 1))  # TM error
         compiler_cfg.balancer_op_override(
             "conv2d_551.dc.sparse_matmul.10.dc.sparse_matmul.1.lc2",
             "grid_shape",

--- a/model_demos/cv_demos/inception_v4/pytorch_inception_v4_timm.py
+++ b/model_demos/cv_demos/inception_v4/pytorch_inception_v4_timm.py
@@ -52,6 +52,7 @@ def run_inception_v4_timm_pytorch():
         compiler_cfg.balancer_op_override("_fused_op_2", "t_stream_shape", (676, 1))  # TM error (ref pybuda#1527)
     elif pybuda.detect_available_devices()[0] == BackendDevice.Wormhole_B0:
         # STEP 1: Set PyBuda configuration parameters
+        compiler_cfg.balancer_op_override("_fused_op_2", "t_stream_shape", (676, 1))  # TM error
         compiler_cfg.balancer_op_override(
             "conv2d_551.dc.sparse_matmul.10.dc.sparse_matmul.1.lc2",
             "grid_shape",

--- a/model_demos/cv_demos/landmark/hand_landmark_lite_1x1.py
+++ b/model_demos/cv_demos/landmark/hand_landmark_lite_1x1.py
@@ -31,6 +31,7 @@ def run_hand_landmark_lite_1x1():
     os.environ["PYBUDA_OVERRIDE_DEVICE_YAML"] = "wormhole_b0_1x1.yaml"
     os.environ["PYBUDA_FORCE_CONV_MULTI_OP_FRACTURE"] = "1"
     os.environ["PYBUDA_ENABLE_SINGLE_BUFFER_FALLBACK"] = "1"
+    compiler_cfg.place_on_new_epoch("conv2d_14.dc.conv2d.3.dc.depthwise.9")
 
     # Download model weights
     url = "https://storage.googleapis.com/mediapipe-assets/hand_landmark_lite.tflite"

--- a/model_demos/cv_demos/retinanet/onnx_retinanet_r101.py
+++ b/model_demos/cv_demos/retinanet/onnx_retinanet_r101.py
@@ -46,6 +46,8 @@ def run_retinanet_r101_640x480_onnx():
         if available_devices[0] == pybuda.BackendDevice.Grayskull:
             os.environ["PYBUDA_RIBBON2"] = "1"
             os.environ["PYBUDA_FORCE_EMULATE_HARVESTED"] = "1"
+        elif available_devices[0] == pybuda.BackendDevice.Wormhole_B0:
+            compiler_cfg.place_on_new_epoch("conv2d_1557.dc.matmul.11")
 
     compiler_cfg = pybuda.config._get_global_compiler_config()
     compiler_cfg.balancer_policy = "Ribbon"

--- a/model_demos/cv_demos/ssd300_resnet50/pytorch_ssd300_resnet50.py
+++ b/model_demos/cv_demos/ssd300_resnet50/pytorch_ssd300_resnet50.py
@@ -64,18 +64,19 @@ def run_pytorch_ssd300_resnet50():
     compiler_cfg = pybuda.config._get_global_compiler_config()
     compiler_cfg.balancer_policy = "Ribbon"
     compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
-    compiler_cfg.amp_level = 1
+    compiler_cfg.balancer_op_override("max_pool2d_14.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (2, 1))
 
     # Device specific configurations
     available_devices = pybuda.detect_available_devices()
     if available_devices:
         if available_devices[0] == BackendDevice.Grayskull:
             os.environ["PYBUDA_RIBBON2"] = "1"
-            compiler_cfg.balancer_op_override("max_pool2d_14.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (2, 1))
+            compiler_cfg.place_on_new_epoch("reshape_769.dc.matmul.13")
+            compiler_cfg.place_on_new_epoch("reshape_769.dc.matmul.7")
 
         if available_devices[0] == BackendDevice.Wormhole_B0:
             compiler_cfg.place_on_new_epoch("conv2d_766.dc.matmul.11")
-            os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "45056"
+            os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "12288"
 
     # STEP 2 : prepare model
     model = torch.hub.load("NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd", pretrained=False)

--- a/model_demos/cv_demos/xception/timm_xception.py
+++ b/model_demos/cv_demos/xception/timm_xception.py
@@ -38,6 +38,7 @@ def run_xception_timm(variant="xception"):
             os.environ["PYBUDA_TEMP_DISABLE_MODEL_KB_PROLOGUE_BW"] = "1"
     if available_devices[0] == BackendDevice.Grayskull:
         compiler_cfg.balancer_policy = "Ribbon"
+        compiler_cfg.place_on_new_epoch("max_pool2d_153.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2")
 
     os.environ["PYBUDA_RIBBON2"] = "1"
     os.environ["PYBUDA_FORCE_CONV_MULTI_OP_FRACTURE"] = "1"

--- a/model_demos/cv_demos/yolo_v5/pytorch_yolov5_480.py
+++ b/model_demos/cv_demos/yolo_v5/pytorch_yolov5_480.py
@@ -29,7 +29,8 @@ def run_pytorch_yolov5_480(variant="yolov5s"):
     if available_devices:
         if available_devices[0] == BackendDevice.Grayskull:
             # Set PyBUDA environment variables
-            os.environ["PYBUDA_PAD_SPARSE_MM"] = "{113:128}"
+            if variant != "yolov5n":
+                os.environ["PYBUDA_PAD_SPARSE_MM"] = "{113:128}"
             os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = f"{16*1024}"
             os.environ["PYBUDA_FORK_JOIN_SKIP_EXPANDING_BUFFERS"] = "1"
             if variant == "yolov5m":
@@ -47,6 +48,7 @@ def run_pytorch_yolov5_480(variant="yolov5s"):
                     "concatenate_40.dc.concatenate.30.dc.concatenate.1.dc.buffer.0", "t_stream_shape", (6, 1)
                 )
                 compiler_cfg.balancer_op_override("conv2d_41.dc.matmul.8", "grid_shape", (5, 5))
+                compiler_cfg.place_on_new_epoch("conv2d_44.dc.matmul.11")
         elif available_devices[0] == BackendDevice.Wormhole_B0:
             # Set PyBUDA environment variables
             compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b

--- a/model_demos/cv_demos/yolo_v5/pytorch_yolov5_640.py
+++ b/model_demos/cv_demos/yolo_v5/pytorch_yolov5_640.py
@@ -52,6 +52,7 @@ def run_pytorch_yolov5_640(variant="yolov5s"):
                     compiler_cfg.place_on_new_epoch("conv2d_210.dc.matmul.11")
                     os.environ["PYBUDA_TEMP_BALANCER_DISABLE_TARGET_PROXIMITY"] = "1"
                     os.environ["PYBUDA_TEMP_RIBBON2_LEGACY_UTIL_EVAL"] = "1"
+                    compiler_cfg.place_on_new_epoch("concatenate_40.dc.concatenate.30.dc.concatenate.0.dc.concatenate.12")
             if model_ckpt in ["yolov5m"]:
                 os.environ["PYBUDA_RIBBON2"] = "1"
                 os.environ["PYBUDA_INSERT_SLICE_FOR_CONCAT"] = "1"
@@ -60,7 +61,7 @@ def run_pytorch_yolov5_640(variant="yolov5s"):
                 compiler_cfg.place_on_new_epoch("conv2d_27.dc.matmul.8")
             if model_ckpt in ["yolov5l"]:
                 compiler_cfg.place_on_new_epoch("conv2d_313.dc.matmul.8")
-                os.environ["PYBUDA_TEMP_DISABLE_MODEL_KB_PROLOGUE_BW"] = "1"
+                os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "74752"
 
         elif available_devices[0] == BackendDevice.Wormhole_B0:
             os.environ["PYBUDA_PAD_SPARSE_MM"] = "{13:16, 3:4}"
@@ -93,6 +94,9 @@ def run_pytorch_yolov5_640(variant="yolov5s"):
                 compiler_cfg.enable_tm_cpu_fallback = True
                 compiler_cfg.balancer_op_override("conv2d_328.dc.matmul.8", "grid_shape", (5, 2))
                 os.environ["PYBUDA_RIBBON2"] = "1"
+                os.environ["PYBUDA_FORK_JOIN_BUF_QUEUES"] = "1"
+                os.environ["PYBUDA_FORK_JOIN_EXPAND_OUTPUT_BUFFERS"] = "1"
+                os.environ["PYBUDA_FORK_JOIN_SKIP_EXPANDING_BUFFERS"] = "1"                
             if model_ckpt == "yolov5x":
                 compiler_cfg.balancer_op_override("concatenate_363.dc.concatenate.0", "grid_shape", (1, 1))
                 compiler_cfg.balancer_op_override("conv2d_41.dc.matmul.8", "t_stream_shape", (1, 1))

--- a/model_demos/nlp_demos/gpt_neo/pytorch_gptneo_causal_lm.py
+++ b/model_demos/nlp_demos/gpt_neo/pytorch_gptneo_causal_lm.py
@@ -34,8 +34,8 @@ def run_gptneo_causal_lm(variant="EleutherAI/gpt-neo-125M"):
 
         if available_devices:
             if available_devices[0] == BackendDevice.Grayskull:
+                compiler_cfg.enable_auto_fusing = False
                 compiler_cfg.balancer_policy = "Ribbon"
-                os.environ["PYBUDA_FORCE_EMULATE_HARVESTED"] = "1"
 
     # Modify Config
     config = GPTNeoConfig.from_pretrained(model_ckpt)


### PR DESCRIPTION
Pipeline - [https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/pipelines/495601](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/pipelines/495601)
Sheet - [https://docs.google.com/spreadsheets/d/1ABTiLjga51q0L4QlfCE2FBPOm_s2c5Lnx0x2UBCsOgU/edit#gid=1569978830](https://docs.google.com/spreadsheets/d/1ABTiLjga51q0L4QlfCE2FBPOm_s2c5Lnx0x2UBCsOgU/edit#gid=1569978830)

Following jobs will be patched on next run 

customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-gs-e150-silicon
customer-pytorch-ssd300-resnet50-ssd300-resnet50-pytorch-gs-e150-golden