### PR TITLE
Add demo script for YOLOX(n300 & n150)- Pytorch

### DIFF
--- a/model_demos/README.md
+++ b/model_demos/README.md
@@ -85,6 +85,7 @@ python cv_demos/resnet/pytorch_resnet.py
 | [YOLOv3](cv_demos/yolo_v3/)                               |   ✔️    |    ✔️    |    ✔️    |        v0.12.3        |
 | [YOLOv5](cv_demos/yolo_v5/)                               |   ✔️    |    ✔️    |    ✔️    |        v0.12.3        |
 | YOLOv6                                                    |   ✘    |    ✘    |    ✘    |          TBD          |
+| [YOLOX](cv_demos/yolo_x/)                                 |   ✘    |    ✘    |    ✔️    |          TBD          |
 
 ### Legend
 

--- a/model_demos/cv_demos/yolo_x/pytorch_yolox.py
+++ b/model_demos/cv_demos/yolo_x/pytorch_yolox.py
@@ -1,0 +1,151 @@
+# yolox demo script
+
+import subprocess
+
+subprocess.run(["pip", "install", "yolox==0.3.0", "--no-deps"])  # Install yolox==0.3.0 without installing its dependencies
+
+import pybuda
+import torch
+import cv2
+import numpy as np
+import requests
+import os
+from pybuda._C.backend_api import BackendDevice
+
+torch.multiprocessing.set_sharing_strategy("file_system")
+from yolox.exp import get_exp
+from yolox.data.data_augment import preproc as preprocess
+from yolox.data.datasets import COCO_CLASSES
+from yolox.utils import multiclass_nms, demo_postprocess
+
+
+def run_yolox_pytorch(variant):
+
+    # Set PyBuda configuration parameters
+    compiler_cfg = pybuda.config._get_global_compiler_config()
+    compiler_cfg.balancer_policy = "Ribbon"
+    compiler_cfg.default_df_override = pybuda.DataFormat.Float16_b
+    os.environ["PYBUDA_DECOMPOSE_SIGMOID"] = "1"
+
+    # Device specific configurations
+    available_devices = pybuda.detect_available_devices()
+    if available_devices:
+        if available_devices[0] == BackendDevice.Wormhole_B0:
+            if variant not in ["yolox_nano", "yolox_s"]:
+                os.environ["PYBUDA_FORK_JOIN_BUF_QUEUES"] = "1"
+                os.environ["PYBUDA_FORK_JOIN_EXPAND_OUTPUT_BUFFERS"] = "1"
+                os.environ["PYBUDA_FORK_JOIN_SKIP_EXPANDING_BUFFERS"] = "1"
+
+            if variant in ["yolox_nano", "yolox_tiny"]:
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.1.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 2))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.3.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 2))
+                os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "81920"
+                if variant == "yolox_nano":
+                    compiler_cfg.balancer_op_override("max_pool2d_630.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (1, 1))
+                elif variant == "yolox_tiny":
+                    compiler_cfg.balancer_op_override("max_pool2d_454.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (1, 1))
+
+            elif variant == "yolox_s":
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.5.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.1.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.3.dc.reshape.0.dc.sparse_matmul.10.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_33.dc.matmul.8", "t_stream_shape", (1, 1))
+                os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "4096"
+                compiler_cfg.place_on_new_epoch("concatenate_1163.dc.sparse_matmul.11.lc2")
+                compiler_cfg.balancer_op_override("max_pool2d_454.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "grid_shape", (1, 2))
+
+            elif variant == "yolox_m":
+                compiler_cfg.place_on_new_epoch("conv2d_811.dc.matmul.8")
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.1.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.3.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 6))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.5.dc.sparse_matmul.9.dc.sparse_matmul.1.lc2", "t_stream_shape", (5, 1))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.5.dc.reshape.0.dc.sparse_matmul.10.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.3.dc.reshape.0.dc.sparse_matmul.10.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.place_on_new_epoch("concatenate_1530.dc.sparse_matmul.11.lc2")
+                os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "4096"
+                compiler_cfg.balancer_op_override("max_pool2d_671.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (169, 1))
+
+            elif variant == "yolox_l":
+                os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "245760"
+                compiler_cfg.place_on_new_epoch("conv2d_1644.dc.matmul.11")
+                compiler_cfg.place_on_new_epoch("concatenate_1897.dc.sparse_matmul.11.lc2")
+
+            elif variant == "yolox_darknet":
+                os.environ["TT_BACKEND_OVERLAY_MAX_EXTRA_BLOB_SIZE"] = "245760"
+                compiler_cfg.place_on_new_epoch("conv2d_1147.dc.matmul.11")
+
+            elif variant == "yolox_x":
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.5.dc.reshape.0.dc.sparse_matmul.4.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.1.dc.reshape.0.dc.sparse_matmul.10.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.3.dc.sparse_matmul.9.dc.sparse_matmul.1.lc2", "t_stream_shape", (5, 1))
+                compiler_cfg.balancer_op_override("conv2d_7.dc.conv2d.3.dc.reshape.0.dc.sparse_matmul.10.lc2", "t_stream_shape", (1, 4))
+                compiler_cfg.place_on_new_epoch("concatenate_2264.dc.sparse_matmul.11.lc2")
+                compiler_cfg.balancer_op_override("max_pool2d_1104.dc.sparse_matmul.5.dc.sparse_matmul.1.lc2", "t_stream_shape", (13, 1))
+
+    # prepare model
+    weight_name = f"{variant}.pth"
+    url = f"https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/{weight_name}"
+    response = requests.get(url)
+    with open(f"{weight_name}", "wb") as file:
+        file.write(response.content)
+
+    if variant == "yolox_darknet":
+        model_name = "yolov3"
+    else:
+        model_name = variant.replace("_", "-")
+
+    exp = get_exp(exp_name=model_name)
+    model = exp.get_model()
+    ckpt = torch.load(f"{variant}.pth", map_location="cpu")
+    model.load_state_dict(ckpt["model"])
+    model.eval()
+    model_name = f"pt_{variant}"
+    tt_model = pybuda.PyTorchModule(f"pt_{variant}", model)
+
+    # prepare input
+    if variant in ["yolox_nano", "yolox_tiny"]:
+        input_shape = (416, 416)
+    else:
+        input_shape = (640, 640)
+
+    url = "http://images.cocodataset.org/val2017/000000397133.jpg"
+    response = requests.get(url)
+    with open("input.jpg", "wb") as f:
+        f.write(response.content)
+    img = cv2.imread("input.jpg")
+    img, ratio = preprocess(img, input_shape)
+    img_tensor = torch.from_numpy(img)
+    img_tensor = img_tensor.unsqueeze(0)
+
+    # Run inference on Tenstorrent device
+    output_q = pybuda.run_inference(tt_model, inputs=[(img_tensor)])
+    output = output_q.get()
+
+    # Post-processing
+    for i in range(len(output)):
+        output[i] = output[i].value().detach().float().numpy()
+
+    predictions = demo_postprocess(output[0], input_shape)[0]
+    boxes = predictions[:, :4]
+    scores = predictions[:, 4:5] * predictions[:, 5:]
+    boxes_xyxy = np.ones_like(boxes)
+    boxes_xyxy[:, 0] = boxes[:, 0] - boxes[:, 2] / 2.0
+    boxes_xyxy[:, 1] = boxes[:, 1] - boxes[:, 3] / 2.0
+    boxes_xyxy[:, 2] = boxes[:, 0] + boxes[:, 2] / 2.0
+    boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2.0
+    boxes_xyxy /= ratio
+    dets = multiclass_nms(boxes_xyxy, scores, nms_thr=0.45, score_thr=0.1)
+    if dets is not None:
+        final_boxes, final_scores, final_cls_inds = dets[:, :4], dets[:, 4], dets[:, 5]
+        for box, score, cls_ind in zip(final_boxes, final_scores, final_cls_inds):
+            class_name = COCO_CLASSES[int(cls_ind)]
+            x_min, y_min, x_max, y_max = box
+            print(f"Class: {class_name}, Confidence: {score}, Coordinates: ({x_min}, {y_min}, {x_max}, {y_max})")
+
+    # remove downloaded weights,image
+    os.remove(weight_name)
+    os.remove("input.jpg")
+
+
+if __name__ == "__main__":
+    run_yolox_pytorch()

--- a/model_demos/pyproject.toml
+++ b/model_demos/pyproject.toml
@@ -88,4 +88,5 @@ markers = [
     "yolov6: tests that involve yolov6",
     "segformer: tests that involve SegFormer",
     "monodle: tests that involve Monodle",
+    "yolox: tests that involve YOLOX",
 ]

--- a/model_demos/tests/test_pytorch_yolox.py
+++ b/model_demos/tests/test_pytorch_yolox.py
@@ -1,0 +1,10 @@
+import pytest
+from cv_demos.yolo_x.pytorch_yolox import run_yolox_pytorch
+
+variants = ["yolox_nano", "yolox_tiny", "yolox_s", "yolox_m", "yolox_l", "yolox_darknet", "yolox_x"]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.yolox
+def test_yolox_pytorch(variant, clear_pybuda, test_device):
+    run_yolox_pytorch(variant)


### PR DESCRIPTION
* Model - YOLOX
* Supported variants - yolox-nano,tiny,s,m,l,darknet,x
* Supported architecture - n300,n150
* Paper - [https://arxiv.org/abs/2107.08430)](https://arxiv.org/abs/2107.08430)
* Repo - [https://github.com/Megvii-BaseDetection/YOLOX)](https://github.com/Megvii-BaseDetection/YOLOX)
* Input size is (1x3x416x416) for light variants(yolox-nano,tiny) and (1x3x640x640) for standard variants(yolox-s,m,l,darknet,x)

Support for e150 & e300 will be enabled soon..
