### PR TITLE
Fix segformer semantic segmentation ci failure

### DIFF
--- a/model_demos/cv_demos/segformer/pytorch_segformer_semantic_segmentation.py
+++ b/model_demos/cv_demos/segformer/pytorch_segformer_semantic_segmentation.py
@@ -50,6 +50,15 @@ def run_segformer_semseg_pytorch(variant="nvidia/segformer-b0-finetuned-ade-512-
             ]:
                 compiler_cfg.amp_level = 1
 
+            if variant == "nvidia/segformer-b2-finetuned-ade-512-512":
+                compiler_cfg.place_on_new_epoch("concatenate_1098.dc.concatenate.0")
+
+            elif variant == "nvidia/segformer-b3-finetuned-ade-512-512":
+                compiler_cfg.place_on_new_epoch("concatenate_1890.dc.concatenate.0")
+
+            elif variant == "nvidia/segformer-b4-finetuned-ade-512-512":
+                compiler_cfg.place_on_new_epoch("concatenate_2748.dc.concatenate.0")
+
     # Load the model from HuggingFace
     model = SegformerForSemanticSegmentation.from_pretrained(variant)
     model.eval()


### PR DESCRIPTION
Fix segformer semantic segmentation model ci failures on Grayskull
• [customer-pytorch-segformer-segformer-seg-pytorch[Grayskull-nvidia/segformer-b4-finetuned-ade-512-512]-gs-e300-silicon](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6947576)
• [customer-pytorch-segformer-segformer-seg-pytorch[Grayskull-nvidia/segformer-b3-finetuned-ade-512-512]-gs-e300-silicon](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6947575)
• [customer-pytorch-segformer-segformer-seg-pytorch[Grayskull-nvidia/segformer-b2-finetuned-ade-512-512]-gs-e300-silicon](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6947574)
• [customer-pytorch-segformer-segformer-seg-pytorch[Golden-nvidia/segformer-b4-finetuned-ade-512-512]-gs-e300-golden](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6946522)
• [customer-pytorch-segformer-segformer-seg-pytorch[Golden-nvidia/segformer-b3-finetuned-ade-512-512]-gs-e300-golden](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6946521)
• [customer-pytorch-segformer-segformer-seg-pytorch[Golden-nvidia/segformer-b2-finetuned-ade-512-512]-gs-e300-golden](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/jobs/6946520)