### PR TITLE
Fix: Correct torchvision installation order in tt-buda-demos

### DIFF
--- a/first_5_steps/1_install_tt_buda.md
+++ b/first_5_steps/1_install_tt_buda.md
@@ -142,7 +142,7 @@ source env/bin/activate
 
 ```bash
 pip install --upgrade pip==24.0
-pip install pybuda-<version>.whl tvm-<version>.whl torchvision-<version>.whl
+pip install torchvision-<version>.whl pybuda-<version>.whl tvm-<version>.whl 
 ```
 
 The `pybuda-<version>.whl` file contains the PyBuda library, the `tvm-<version>.whl` file contains the latest TVM downloaded release, and the `torchvision-<version>.whl` file bundles the torchvision library.


### PR DESCRIPTION
Following the installation issue I created now, here is my suggested fix.

This pull request addresses an installation error encountered when installing `pybuda` on Linux systems, caused by an incorrect installation order of the required wheel files.

**Problem:**

The previous installation instructions in `1_install_tt_buda.md` specified the following order for installing wheel files:

pip install pybuda-<version>.whl tvm-<version>.whl torchvision-<version>.whl

This order led to the following error on Linux (**specifically tested on a Linux environment that installs pybuda for the first time**):

ERROR: Could not find a version that satisfies the requirement torchvision==0.16.0+fbb4cc5 (from pybuda) (from versions: 0.1.6, 0.1.7, ..., 0.20.1)
ERROR: No matching distribution found for torchvision==0.16.0+fbb4cc5

This error occurs because pybuda depends on a specific version of torchvision provided by Tenstorrent. Installing pybuda before the Tenstorrent-provided torchvision wheel resulted in pip attempting to resolve the dependency from the standard PyPI repository, which does not contain the required version.


**Solution:**

This pull request corrects the installation order in 1_install_tt_buda.md to:

pip install torchvision-<version>.whl pybuda-<version>.whl tvm-<version>.whl

Installing the Tenstorrent-provided torchvision wheel first ensures that the correct version is available when pybuda is installed, satisfying its dependency.


**Testing:**

After applying this change, the installation was successfully tested on a Linux environment. The installation now completes without errors.


**Changes:**

Modified tt-buda-demos/first_5_steps/1_install_tt_buda.md: 
 Changed the pip install command order from 
pybuda-<version>.whl tvm-<version>.whl torchvision-<version>.whl 
to 
torchvision-<version>.whl pybuda-<version>.whl tvm-<version>.whl.

This simple change resolves the installation issue and ensures a smooth installation experience for all users.